### PR TITLE
chore: migrate Connector trait to native AFIT (drop async-trait)

### DIFF
--- a/crates/connector-rss/Cargo.toml
+++ b/crates/connector-rss/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 
 [dependencies]
 ferrisletter-connector = { path = "../connector" }
-async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
 feed-rs = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/connector-static/Cargo.toml
+++ b/crates/connector-static/Cargo.toml
@@ -8,7 +8,6 @@ repository.workspace = true
 
 [dependencies]
 ferrisletter-connector = { path = "../connector" }
-async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/connector-static/src/lib.rs
+++ b/crates/connector-static/src/lib.rs
@@ -34,7 +34,6 @@
 
 use std::path::Path;
 
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use ferrisletter_connector::{
     Connector, ConnectorError, Item, ItemDetail, SearchFilters, Topic, UserPrefs,
@@ -82,7 +81,6 @@ impl StaticConnector {
     }
 }
 
-#[async_trait]
 impl Connector for StaticConnector {
     async fn list_topics(&self) -> Result<Vec<Topic>, ConnectorError> {
         Ok(self.data.topics.clone())

--- a/crates/connector/Cargo.toml
+++ b/crates/connector/Cargo.toml
@@ -9,5 +9,4 @@ repository.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-async-trait = "0.1"
 thiserror = "2"

--- a/crates/connector/src/lib.rs
+++ b/crates/connector/src/lib.rs
@@ -4,6 +4,8 @@
 //! Third-party connector authors should depend on this crate and implement the trait
 //! to integrate their content source with Ferrisletter.
 
+use std::future::Future;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -11,30 +13,35 @@ mod error;
 pub use error::ConnectorError;
 
 /// A content source that provides news items to Ferrisletter.
-#[async_trait::async_trait]
 pub trait Connector: Send + Sync {
     /// Returns the available content categories.
-    async fn list_topics(&self) -> Result<Vec<Topic>, ConnectorError>;
+    fn list_topics(&self) -> impl Future<Output = Result<Vec<Topic>, ConnectorError>> + Send;
 
     /// Returns recent items, filtered by user preferences.
-    async fn get_latest_items(&self, prefs: &UserPrefs) -> Result<Vec<Item>, ConnectorError>;
+    fn get_latest_items(
+        &self,
+        prefs: &UserPrefs,
+    ) -> impl Future<Output = Result<Vec<Item>, ConnectorError>> + Send;
 
     /// Returns the full content for a specific item.
-    async fn get_item_detail(&self, id: &str) -> Result<ItemDetail, ConnectorError>;
+    fn get_item_detail(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = Result<ItemDetail, ConnectorError>> + Send;
 
     /// Finds items matching a query across all past content.
-    async fn search(
+    fn search(
         &self,
         query: &str,
         filters: &SearchFilters,
-    ) -> Result<Vec<Item>, ConnectorError>;
+    ) -> impl Future<Output = Result<Vec<Item>, ConnectorError>> + Send;
 
     /// Returns a summary of items since a given point in time.
-    async fn get_recap(
+    fn get_recap(
         &self,
         since: DateTime<Utc>,
         prefs: &UserPrefs,
-    ) -> Result<Vec<Item>, ConnectorError>;
+    ) -> impl Future<Output = Result<Vec<Item>, ConnectorError>> + Send;
 }
 
 /// A content category within a newsletter.


### PR DESCRIPTION
## Summary

- Replaces `#[async_trait::async_trait]` in the `Connector` trait with native `fn ... -> impl Future<Output = ...> + Send`, matching the pattern used in FerrisKey
- Removes the `async-trait` dependency from `connector`, `connector-static`, and `connector-rss`
- Implementations continue to use plain `async fn` — the compiler handles desugaring in edition 2024

## Why

`async-trait` was required before Rust stabilised async fn in traits. Since Ferrisletter uses edition 2024, we can use AFIT natively. This aligns the codebase with FerrisKey's async conventions and removes an unnecessary macro dependency.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 15/15 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)