### PR TITLE
feat: basic MCP server with 5 tools

### DIFF
--- a/crates/connector/src/lib.rs
+++ b/crates/connector/src/lib.rs
@@ -5,6 +5,7 @@
 //! to integrate their content source with Ferrisletter.
 
 use std::future::Future;
+use std::pin::Pin;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -99,6 +100,118 @@ pub enum SummaryLength {
     #[default]
     Standard,
     Detailed,
+}
+
+// --- Type erasure ---
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Object-safe backing trait — keeps `Connector` methods callable through `dyn`.
+trait ErasedConnector: Send + Sync {
+    fn list_topics_erased(&self) -> BoxFuture<'_, Result<Vec<Topic>, ConnectorError>>;
+    fn get_latest_items_erased<'a>(
+        &'a self,
+        prefs: &'a UserPrefs,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>>;
+    fn get_item_detail_erased<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> BoxFuture<'a, Result<ItemDetail, ConnectorError>>;
+    fn search_erased<'a>(
+        &'a self,
+        query: &'a str,
+        filters: &'a SearchFilters,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>>;
+    fn get_recap_erased<'a>(
+        &'a self,
+        since: DateTime<Utc>,
+        prefs: &'a UserPrefs,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>>;
+}
+
+impl<C: Connector + Send + Sync> ErasedConnector for C {
+    fn list_topics_erased(&self) -> BoxFuture<'_, Result<Vec<Topic>, ConnectorError>> {
+        Box::pin(Connector::list_topics(self))
+    }
+    fn get_latest_items_erased<'a>(
+        &'a self,
+        prefs: &'a UserPrefs,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>> {
+        Box::pin(Connector::get_latest_items(self, prefs))
+    }
+    fn get_item_detail_erased<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> BoxFuture<'a, Result<ItemDetail, ConnectorError>> {
+        Box::pin(Connector::get_item_detail(self, id))
+    }
+    fn search_erased<'a>(
+        &'a self,
+        query: &'a str,
+        filters: &'a SearchFilters,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>> {
+        Box::pin(Connector::search(self, query, filters))
+    }
+    fn get_recap_erased<'a>(
+        &'a self,
+        since: DateTime<Utc>,
+        prefs: &'a UserPrefs,
+    ) -> BoxFuture<'a, Result<Vec<Item>, ConnectorError>> {
+        Box::pin(Connector::get_recap(self, since, prefs))
+    }
+}
+
+/// A type-erased [`Connector`] that can be stored as `Arc<BoxedConnector>`.
+///
+/// Useful when the concrete connector type is not known at compile time
+/// (e.g. selected from config).
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use ferrisletter_connector::{BoxedConnector, Connector};
+///
+/// fn start(connector: Arc<BoxedConnector>) { /* ... */ }
+///
+/// let conn = StaticConnector::from_json(data)?;
+/// start(Arc::new(BoxedConnector::new(conn)));
+/// ```
+pub struct BoxedConnector(Box<dyn ErasedConnector>);
+
+impl BoxedConnector {
+    /// Wrap any [`Connector`] for type-erased use.
+    pub fn new<C: Connector + Send + Sync + 'static>(connector: C) -> Self {
+        Self(Box::new(connector))
+    }
+}
+
+impl Connector for BoxedConnector {
+    // list_topics takes only &self — RPIT works fine here.
+    fn list_topics(&self) -> impl Future<Output = Result<Vec<Topic>, ConnectorError>> + Send {
+        self.0.list_topics_erased()
+    }
+
+    // Methods with additional reference params use `async fn` to let the compiler
+    // handle lifetime capture automatically, avoiding E0700.
+    async fn get_latest_items(&self, prefs: &UserPrefs) -> Result<Vec<Item>, ConnectorError> {
+        self.0.get_latest_items_erased(prefs).await
+    }
+    async fn get_item_detail(&self, id: &str) -> Result<ItemDetail, ConnectorError> {
+        self.0.get_item_detail_erased(id).await
+    }
+    async fn search(
+        &self,
+        query: &str,
+        filters: &SearchFilters,
+    ) -> Result<Vec<Item>, ConnectorError> {
+        self.0.search_erased(query, filters).await
+    }
+    async fn get_recap(
+        &self,
+        since: DateTime<Utc>,
+        prefs: &UserPrefs,
+    ) -> Result<Vec<Item>, ConnectorError> {
+        self.0.get_recap_erased(since, prefs).await
+    }
 }
 
 /// Filters for searching across past content.

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,9 +8,13 @@ repository.workspace = true
 
 [dependencies]
 ferrisletter-connector = { path = "../connector" }
-rmcp = { version = "0.1", features = ["server", "transport-sse"] }
-tokio = { version = "1", features = ["full"] }
+ferrisletter-connector-static = { path = "../connector-static" }
+rmcp = { version = "0.1", features = ["server", "transport-io", "transport-sse-server"] }
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/server/data/sample.json
+++ b/crates/server/data/sample.json
@@ -1,0 +1,97 @@
+{
+  "topics": [
+    {
+      "id": "rust",
+      "label": "Rust",
+      "description": "News and releases from the Rust ecosystem",
+      "tags": ["rust", "programming", "systems"]
+    },
+    {
+      "id": "ai",
+      "label": "AI & LLMs",
+      "description": "Large language models, agents, and AI tooling",
+      "tags": ["ai", "llm", "agents", "mcp"]
+    },
+    {
+      "id": "open-source",
+      "label": "Open Source",
+      "description": "Notable open-source releases and community news",
+      "tags": ["open-source", "github", "community"]
+    }
+  ],
+  "items": [
+    {
+      "id": "rust-2024-edition",
+      "topic_id": "rust",
+      "headline": "Rust 2024 edition stabilised",
+      "summary": "The Rust 2024 edition ships with native async fn in traits (AFIT), improved ergonomics for closures, and a cleaner approach to lifetime capture in return-position impl trait.",
+      "tags": ["rust", "edition", "afit"],
+      "source": "blog.rust-lang.org",
+      "published": "2024-02-15T10:00:00Z",
+      "body": "The Rust 2024 edition is now stable. The headline feature is async fn in traits (AFIT) — you can now write `async fn` directly in trait definitions without the async-trait crate. Return-position impl Trait (RPIT) in traits also captures lifetimes correctly by default. Other improvements include gen blocks for iterator authoring and refined closure capture semantics.",
+      "links": [
+        { "url": "https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html", "label": "Rust 1.85 release notes" }
+      ],
+      "read_time": "4 min"
+    },
+    {
+      "id": "mcp-rust-sdk",
+      "topic_id": "rust",
+      "headline": "Official Rust MCP SDK (rmcp) reaches 0.1",
+      "summary": "The Model Context Protocol now has an official Rust SDK. rmcp provides server and client implementations with proc-macro ergonomics for registering tools.",
+      "tags": ["rust", "mcp", "sdk"],
+      "source": "github.com/modelcontextprotocol/rust-sdk",
+      "published": "2024-03-01T08:00:00Z",
+      "body": "rmcp is the official Rust implementation of the Model Context Protocol. It ships with a `#[tool]` proc-macro for zero-boilerplate tool registration, support for stdio and SSE transports, and full async/await support via Tokio. The SDK mirrors the patterns established by the TypeScript and Python SDKs while feeling idiomatic to Rust.",
+      "links": [
+        { "url": "https://github.com/modelcontextprotocol/rust-sdk", "label": "GitHub" },
+        { "url": "https://docs.rs/rmcp", "label": "Docs" }
+      ],
+      "read_time": "3 min"
+    },
+    {
+      "id": "mcp-protocol-v1",
+      "topic_id": "ai",
+      "headline": "Model Context Protocol 1.0 released",
+      "summary": "Anthropic open-sources the Model Context Protocol — a standard for connecting LLMs to tools, data sources, and external services. Major IDE and client support announced at launch.",
+      "tags": ["mcp", "anthropic", "protocol", "llm"],
+      "source": "anthropic.com",
+      "published": "2024-01-15T14:00:00Z",
+      "body": "The Model Context Protocol (MCP) defines how LLM clients discover and call tools exposed by servers. It supports three primitives: tools (callable functions), resources (data the model can read), and prompts (reusable prompt templates). The protocol uses JSON-RPC over stdio or SSE. At launch, Claude Desktop, Cursor, and Zed all ship with MCP support.",
+      "links": [
+        { "url": "https://modelcontextprotocol.io", "label": "MCP specification" },
+        { "url": "https://github.com/modelcontextprotocol", "label": "GitHub org" }
+      ],
+      "read_time": "5 min"
+    },
+    {
+      "id": "ferrisletter-launch",
+      "topic_id": "open-source",
+      "headline": "Ferrisletter: newsletters as MCP conversations",
+      "summary": "Ferrislabs ships Ferrisletter — an open-source MCP server that turns newsletters into chat-native experiences. Subscribe to topics, ask for headlines, and expand what interests you.",
+      "tags": ["ferrisletter", "mcp", "newsletter", "open-source"],
+      "source": "github.com/ferrislabs/ferrisletter",
+      "published": "2024-03-10T09:00:00Z",
+      "body": "Ferrisletter reimagines the newsletter as a conversation. Instead of reading a wall of text, your LLM client delivers compact headlines via the MCP protocol. You expand what interests you, skip the rest, and ask for recaps when you've been away. Built in Rust with rmcp, the connector SDK is open source and anyone can write a connector for their own content source.",
+      "links": [
+        { "url": "https://github.com/ferrislabs/ferrisletter", "label": "GitHub" },
+        { "url": "https://site.ferrisletter.xyz", "label": "Website" }
+      ],
+      "read_time": "3 min"
+    },
+    {
+      "id": "tokio-1-40",
+      "topic_id": "rust",
+      "headline": "Tokio 1.40 ships improved task metrics",
+      "summary": "Tokio 1.40 adds per-task instrumentation for diagnosing async runtimes in production, alongside performance improvements to the timer wheel.",
+      "tags": ["rust", "tokio", "async"],
+      "source": "tokio.rs",
+      "published": "2024-02-01T11:00:00Z",
+      "body": "Tokio 1.40 introduces task metrics — you can now instrument individual async tasks to measure poll time, schedule delay, and resource usage. This makes it much easier to find hot tasks and unexpected blocking in production systems. The timer wheel also received a significant rewrite that reduces allocation pressure for workloads with many short-lived timers.",
+      "links": [
+        { "url": "https://tokio.rs/blog/2024-02-tokio-1-40", "label": "Release post" }
+      ],
+      "read_time": "3 min"
+    }
+  ]
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,12 +1,59 @@
-fn main() {
-    tracing_subscriber::fmt::init();
-    tracing::info!("ferrisletter server starting");
+mod server;
 
-    // TODO: Initialize MCP server with rmcp
-    // TODO: Register connector from config
-    // TODO: Register tools (list_topics, get_latest, expand, search, recap)
-    // TODO: Register UI resources
-    // TODO: Start transport (stdio or SSE)
+use std::sync::Arc;
 
-    println!("ferrisletter v{}", env!("CARGO_PKG_VERSION"));
+use ferrisletter_connector::BoxedConnector;
+use ferrisletter_connector_static::StaticConnector;
+use rmcp::ServiceExt;
+use rmcp::transport::stdio;
+use server::FerrislletterServer;
+
+/// Embedded sample data — used when `FERRISLETTER_DATA` is not set.
+const SAMPLE_DATA: &str = include_str!("../data/sample.json");
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // MCP stdio transport uses stdout for the protocol — send logs to stderr.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .init();
+
+    tracing::info!("ferrisletter v{} starting", env!("CARGO_PKG_VERSION"));
+
+    // Load connector — from file if FERRISLETTER_DATA is set, otherwise use embedded sample.
+    let connector: Arc<BoxedConnector> = match std::env::var("FERRISLETTER_DATA") {
+        Ok(path) => {
+            tracing::info!(path, "loading data from file");
+            Arc::new(BoxedConnector::new(
+                StaticConnector::from_file(&path)
+                    .map_err(|e| anyhow::anyhow!("failed to load '{path}': {e}"))?,
+            ))
+        }
+        Err(_) => {
+            tracing::info!("no FERRISLETTER_DATA set — using embedded sample data");
+            Arc::new(BoxedConnector::new(
+                StaticConnector::from_json(SAMPLE_DATA)
+                    .expect("embedded sample data must be valid"),
+            ))
+        }
+    };
+
+    let server = FerrislletterServer::new(connector);
+
+    tracing::info!("serving over stdio");
+    let service = server
+        .serve(stdio())
+        .await
+        .inspect_err(|e| tracing::error!("failed to start server: {e}"))?;
+
+    service
+        .waiting()
+        .await
+        .inspect_err(|e| tracing::error!("server error: {e}"))?;
+
+    Ok(())
 }

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1,0 +1,210 @@
+//! Ferrisletter MCP server — tool definitions and handler.
+
+use std::sync::Arc;
+
+use chrono::DateTime;
+use ferrisletter_connector::{BoxedConnector, Connector, SearchFilters, UserPrefs};
+use rmcp::{
+    ServerHandler,
+    model::{Implementation, ServerCapabilities, ServerInfo},
+    schemars, tool,
+};
+use serde::Deserialize;
+
+/// The Ferrisletter MCP server.
+///
+/// Holds a type-erased connector and exposes newsletter content as MCP tools.
+#[derive(Clone)]
+pub struct FerrislletterServer {
+    connector: Arc<BoxedConnector>,
+}
+
+impl FerrislletterServer {
+    pub fn new(connector: Arc<BoxedConnector>) -> Self {
+        Self { connector }
+    }
+}
+
+// --- Tool parameter types ---
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetLatestParams {
+    /// Topic IDs to filter by. Leave empty or omit for all topics.
+    pub topics: Option<Vec<String>>,
+    /// Maximum number of items to return.
+    pub max_items: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetItemParams {
+    /// Item ID as returned by `ferrisletter_get_latest` or `ferrisletter_search`.
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SearchParams {
+    /// Keywords to match in headlines, summaries, and tags.
+    pub query: String,
+    /// Topic IDs to filter by.
+    pub topics: Option<Vec<String>>,
+    /// Tags to filter by.
+    pub tags: Option<Vec<String>>,
+    /// Only return items published after this date (ISO 8601, e.g. `2024-01-01T00:00:00Z`).
+    pub since: Option<String>,
+    /// Only return items published before this date (ISO 8601).
+    pub until: Option<String>,
+    /// Maximum number of results.
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RecapParams {
+    /// Recap items published after this date (ISO 8601, e.g. `2024-01-01T00:00:00Z`).
+    pub since: String,
+    /// Topic IDs to filter by. Leave empty or omit for all topics.
+    pub topics: Option<Vec<String>>,
+    /// Maximum number of items to return.
+    pub max_items: Option<usize>,
+}
+
+// --- Tools ---
+
+#[tool(tool_box)]
+impl FerrislletterServer {
+    /// List available newsletter topics.
+    #[tool(
+        description = "List available newsletter topics and their descriptions. \
+        Call this first to discover what content is available."
+    )]
+    async fn ferrisletter_list_topics(&self) -> Result<String, String> {
+        let topics = self
+            .connector
+            .list_topics()
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string_pretty(&topics).map_err(|e| e.to_string())
+    }
+
+    /// Get the latest items from the newsletter.
+    #[tool(
+        description = "Get the latest newsletter items as compact headlines and summaries. \
+        Filter by topic or limit the count. \
+        Use `ferrisletter_get_item` to read the full text of anything interesting."
+    )]
+    async fn ferrisletter_get_latest(
+        &self,
+        #[tool(aggr)] params: GetLatestParams,
+    ) -> Result<String, String> {
+        let prefs = UserPrefs {
+            topics_of_interest: params.topics.unwrap_or_default(),
+            max_items: params.max_items,
+            ..Default::default()
+        };
+        let items = self
+            .connector
+            .get_latest_items(&prefs)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string_pretty(&items).map_err(|e| e.to_string())
+    }
+
+    /// Get the full content of a specific item.
+    #[tool(
+        description = "Get the full body text, links, and metadata for a specific newsletter item \
+        by its ID. IDs come from `ferrisletter_get_latest` or `ferrisletter_search`."
+    )]
+    async fn ferrisletter_get_item(
+        &self,
+        #[tool(aggr)] params: GetItemParams,
+    ) -> Result<String, String> {
+        let detail = self
+            .connector
+            .get_item_detail(&params.id)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string_pretty(&detail).map_err(|e| e.to_string())
+    }
+
+    /// Search newsletter content.
+    #[tool(
+        description = "Search newsletter content by keyword, topic, tags, or date range. \
+        An empty query with filters acts as a pure filter. \
+        Returns compact item summaries — use `ferrisletter_get_item` to expand one."
+    )]
+    async fn ferrisletter_search(
+        &self,
+        #[tool(aggr)] params: SearchParams,
+    ) -> Result<String, String> {
+        let parse_dt = |s: &str| {
+            DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| format!("invalid datetime '{s}': {e}"))
+        };
+
+        let filters = SearchFilters {
+            topic_ids: params.topics.unwrap_or_default(),
+            tags: params.tags.unwrap_or_default(),
+            since: params.since.as_deref().map(parse_dt).transpose()?,
+            until: params.until.as_deref().map(parse_dt).transpose()?,
+            limit: params.limit,
+        };
+
+        let items = self
+            .connector
+            .search(&params.query, &filters)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string_pretty(&items).map_err(|e| e.to_string())
+    }
+
+    /// Get a recap of items published since a given date.
+    #[tool(
+        description = "Summarise what happened in the newsletter since a given date. \
+        Perfect for 'what did I miss this week?' queries. \
+        Returns compact headlines — use `ferrisletter_get_item` to dig into anything."
+    )]
+    async fn ferrisletter_recap(
+        &self,
+        #[tool(aggr)] params: RecapParams,
+    ) -> Result<String, String> {
+        let since = DateTime::parse_from_rfc3339(&params.since)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .map_err(|e| format!("invalid datetime '{}': {e}", params.since))?;
+
+        let prefs = UserPrefs {
+            topics_of_interest: params.topics.unwrap_or_default(),
+            max_items: params.max_items,
+            ..Default::default()
+        };
+
+        let items = self
+            .connector
+            .get_recap(since, &prefs)
+            .await
+            .map_err(|e| e.to_string())?;
+        serde_json::to_string_pretty(&items).map_err(|e| e.to_string())
+    }
+}
+
+#[tool(tool_box)]
+impl ServerHandler for FerrislletterServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            server_info: Implementation {
+                name: "ferrisletter".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+            },
+            instructions: Some(
+                "Ferrisletter is a conversational newsletter platform. \
+                Start with `ferrisletter_list_topics` to see what's available, \
+                then `ferrisletter_get_latest` to browse headlines. \
+                Expand anything interesting with `ferrisletter_get_item`, \
+                search across past content with `ferrisletter_search`, \
+                or catch up on what you missed with `ferrisletter_recap`."
+                    .into(),
+            ),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`BoxedConnector`** added to the connector SDK — type-erases any `Connector` implementation for use with `Arc<BoxedConnector>`. Needed because AFIT traits (`impl Future + Send` return types) are not object-safe in Rust 2024.

- **`FerrislletterServer`** — implements `ServerHandler` via rmcp's `#[tool(tool_box)]` macro, exposing five MCP tools:
  | Tool | Description |
  |------|-------------|
  | `ferrisletter_list_topics` | Discover available topics |
  | `ferrisletter_get_latest` | Browse headlines (filter by topic, limit count) |
  | `ferrisletter_get_item` | Expand a specific item to full body + links |
  | `ferrisletter_search` | Keyword + topic/tag/date range search |
  | `ferrisletter_recap` | "What did I miss since X?" |

- **Transport**: stdio by default — compatible with Claude Desktop, Cursor, Zed, and any MCP client that spawns a child process. Logs go to stderr to keep stdout clean for the protocol.

- **Data source**: reads `FERRISLETTER_DATA` env var (path to a static JSON file) or falls back to embedded sample data (3 topics, 5 items covering Rust, AI/MCP, and open source).

## Using it

```bash
# Build
cargo build -p ferrisletter-server

# Run with sample data (stdio)
./target/debug/ferrisletter-server

# Run with custom data
FERRISLETTER_DATA=./my-newsletter.json ./target/debug/ferrisletter-server
```

**Claude Desktop config** (`claude_desktop_config.json`):
```json
{
  "mcpServers": {
    "ferrisletter": {
      "command": "/path/to/ferrisletter-server"
    }
  }
}
```

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)