### PR TITLE
feat(server): TOML configuration file (#14)

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,11 +8,14 @@ repository.workspace = true
 
 [dependencies]
 ferrisletter-connector = { path = "../connector" }
+ferrisletter-connector-rss = { path = "../connector-rss" }
 ferrisletter-connector-static = { path = "../connector-static" }
 rmcp = { version = "0.1", features = ["server", "transport-io", "transport-sse-server"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 schemars = "0.8"
+thiserror = "2"
+toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,0 +1,200 @@
+//! Configuration file parsing for the Ferrisletter server.
+//!
+//! Looks for config in this order:
+//! 1. `--config <path>` CLI argument
+//! 2. `FERRISLETTER_CONFIG` environment variable
+//! 3. `./ferrisletter.toml` in the current directory
+//!
+//! Falls back to built-in defaults (stdio transport + embedded sample data)
+//! if no config file is found.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Top-level configuration.
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub transport: TransportConfig,
+
+    #[serde(default)]
+    pub connector: ConnectorConfig,
+}
+
+// --- Transport ---
+
+#[derive(Debug, Deserialize)]
+pub struct TransportConfig {
+    #[serde(default)]
+    pub mode: TransportMode,
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            mode: TransportMode::Stdio,
+            host: default_host(),
+            port: default_port(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportMode {
+    #[default]
+    Stdio,
+    Sse,
+}
+
+fn default_host() -> String {
+    "127.0.0.1".to_string()
+}
+fn default_port() -> u16 {
+    3000
+}
+
+// --- Connector ---
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ConnectorConfig {
+    /// Load content from a static JSON file.
+    Static { path: PathBuf },
+    /// Aggregate one or more RSS/Atom feeds.
+    Rss { feeds: Vec<FeedConfig> },
+}
+
+impl Default for ConnectorConfig {
+    fn default() -> Self {
+        // No config — use embedded sample data (path = "").
+        ConnectorConfig::Static {
+            path: PathBuf::new(),
+        }
+    }
+}
+
+/// Configuration for a single RSS/Atom feed.
+#[derive(Debug, Deserialize, Clone)]
+pub struct FeedConfig {
+    pub topic_id: String,
+    pub topic_label: String,
+    pub topic_description: String,
+    #[serde(default)]
+    pub topic_tags: Vec<String>,
+    pub url: String,
+}
+
+// --- Loading ---
+
+/// Errors that can occur when loading a config file.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config file '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to parse config file '{path}': {source}")]
+    Parse {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+}
+
+/// Resolve the config file path from CLI args or environment, then load it.
+///
+/// Returns `None` if no config file is specified and `./ferrisletter.toml`
+/// does not exist — the caller should fall back to built-in defaults.
+pub fn load(cli_path: Option<&str>) -> Result<Option<Config>, ConfigError> {
+    let path = resolve_path(cli_path);
+    match path {
+        Some(p) => load_file(&p).map(Some),
+        None => Ok(None),
+    }
+}
+
+fn resolve_path(cli_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(p) = cli_path {
+        return Some(PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("FERRISLETTER_CONFIG") {
+        return Some(PathBuf::from(p));
+    }
+    let default = PathBuf::from("ferrisletter.toml");
+    if default.exists() {
+        return Some(default);
+    }
+    None
+}
+
+fn load_file(path: &Path) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    toml::from_str(&content).map_err(|e| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: e,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_stdio_static_config() {
+        let toml = r#"
+            [transport]
+            mode = "stdio"
+
+            [connector]
+            type = "static"
+            path = "data/newsletter.json"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.transport.mode, TransportMode::Stdio);
+        assert!(matches!(config.connector, ConnectorConfig::Static { .. }));
+    }
+
+    #[test]
+    fn parses_sse_rss_config() {
+        let toml = r#"
+            [transport]
+            mode = "sse"
+            host = "0.0.0.0"
+            port = 8080
+
+            [connector]
+            type = "rss"
+
+            [[connector.feeds]]
+            topic_id    = "rust"
+            topic_label = "Rust"
+            topic_description = "Rust news"
+            topic_tags  = ["rust"]
+            url         = "https://blog.rust-lang.org/feed.xml"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.transport.mode, TransportMode::Sse);
+        assert_eq!(config.transport.port, 8080);
+        if let ConnectorConfig::Rss { feeds } = &config.connector {
+            assert_eq!(feeds.len(), 1);
+            assert_eq!(feeds[0].topic_id, "rust");
+        } else {
+            panic!("expected RSS connector");
+        }
+    }
+
+    #[test]
+    fn defaults_to_stdio_when_transport_omitted() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(config.transport.mode, TransportMode::Stdio);
+    }
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,14 +1,19 @@
+mod config;
 mod server;
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use ferrisletter_connector::BoxedConnector;
+use ferrisletter_connector_rss::{FeedConfig as RssFeedConfig, RssConnector};
 use ferrisletter_connector_static::StaticConnector;
 use rmcp::ServiceExt;
 use rmcp::transport::stdio;
 use server::FerrislletterServer;
 
-/// Embedded sample data — used when `FERRISLETTER_DATA` is not set.
+use crate::config::{ConnectorConfig, TransportMode};
+
+/// Embedded sample data — used when no config or data file is provided.
 const SAMPLE_DATA: &str = include_str!("../data/sample.json");
 
 #[tokio::main]
@@ -24,36 +29,86 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("ferrisletter v{} starting", env!("CARGO_PKG_VERSION"));
 
-    // Load connector — from file if FERRISLETTER_DATA is set, otherwise use embedded sample.
-    let connector: Arc<BoxedConnector> = match std::env::var("FERRISLETTER_DATA") {
-        Ok(path) => {
-            tracing::info!(path, "loading data from file");
+    // `--config <path>` CLI arg takes precedence over everything else.
+    let cli_config: Option<String> = std::env::args().skip_while(|a| a != "--config").nth(1);
+
+    let cfg = config::load(cli_config.as_deref()).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Build connector from config.
+    let connector: Arc<BoxedConnector> = match cfg.as_ref().map(|c| &c.connector) {
+        Some(ConnectorConfig::Static { path }) if !path.as_os_str().is_empty() => {
+            tracing::info!(path = %path.display(), "loading static connector");
             Arc::new(BoxedConnector::new(
-                StaticConnector::from_file(&path)
-                    .map_err(|e| anyhow::anyhow!("failed to load '{path}': {e}"))?,
+                StaticConnector::from_file(path)
+                    .map_err(|e| anyhow::anyhow!("failed to load '{}': {e}", path.display()))?,
             ))
         }
-        Err(_) => {
-            tracing::info!("no FERRISLETTER_DATA set — using embedded sample data");
-            Arc::new(BoxedConnector::new(
-                StaticConnector::from_json(SAMPLE_DATA)
-                    .expect("embedded sample data must be valid"),
-            ))
+        Some(ConnectorConfig::Rss { feeds }) => {
+            tracing::info!(feeds = feeds.len(), "loading RSS connector");
+            let rss_feeds = feeds
+                .iter()
+                .map(|f| RssFeedConfig {
+                    topic_id: f.topic_id.clone(),
+                    topic_label: f.topic_label.clone(),
+                    topic_description: f.topic_description.clone(),
+                    topic_tags: f.topic_tags.clone(),
+                    url: f.url.clone(),
+                })
+                .collect();
+            Arc::new(BoxedConnector::new(RssConnector::new(rss_feeds)))
         }
+        // No config or empty static path — fall back to env var or embedded sample.
+        _ => match std::env::var("FERRISLETTER_DATA") {
+            Ok(path) => {
+                tracing::info!(path, "loading static connector from FERRISLETTER_DATA");
+                Arc::new(BoxedConnector::new(
+                    StaticConnector::from_file(&path)
+                        .map_err(|e| anyhow::anyhow!("failed to load '{path}': {e}"))?,
+                ))
+            }
+            Err(_) => {
+                tracing::info!("using embedded sample data");
+                Arc::new(BoxedConnector::new(
+                    StaticConnector::from_json(SAMPLE_DATA)
+                        .expect("embedded sample data must be valid"),
+                ))
+            }
+        },
     };
 
     let server = FerrislletterServer::new(connector);
 
-    tracing::info!("serving over stdio");
-    let service = server
-        .serve(stdio())
-        .await
-        .inspect_err(|e| tracing::error!("failed to start server: {e}"))?;
+    // Start transport.
+    let mode = cfg
+        .map(|c| c.transport.mode)
+        .unwrap_or(TransportMode::Stdio);
 
-    service
-        .waiting()
-        .await
-        .inspect_err(|e| tracing::error!("server error: {e}"))?;
+    match mode {
+        TransportMode::Sse => {
+            let cfg2 = config::load(cli_config.as_deref())
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .unwrap_or_default();
+            let addr: SocketAddr =
+                format!("{}:{}", cfg2.transport.host, cfg2.transport.port).parse()?;
+            tracing::info!(%addr, "serving over SSE");
+            let ct = rmcp::transport::sse_server::SseServer::serve(addr)
+                .await?
+                .with_service(move || server.clone());
+            tokio::signal::ctrl_c().await?;
+            ct.cancel();
+        }
+        TransportMode::Stdio => {
+            tracing::info!("serving over stdio");
+            let service = server
+                .serve(stdio())
+                .await
+                .inspect_err(|e| tracing::error!("failed to start server: {e}"))?;
+            service
+                .waiting()
+                .await
+                .inspect_err(|e| tracing::error!("server error: {e}"))?;
+        }
+    }
 
     Ok(())
 }

--- a/examples/ferrisletter.toml
+++ b/examples/ferrisletter.toml
@@ -1,0 +1,52 @@
+# ferrisletter.toml — example configuration file
+#
+# Run with:
+#   ferrisletter-server --config ferrisletter.toml
+#
+# Or set the path via environment variable:
+#   FERRISLETTER_CONFIG=/path/to/ferrisletter.toml ferrisletter-server
+
+# --------------------------------------------------------------------------
+# Transport
+# --------------------------------------------------------------------------
+
+[transport]
+# "stdio"  — communicate over stdin/stdout (default, works with Claude Desktop,
+#             Cursor, Zed, and any MCP client that spawns a child process)
+# "sse"    — serve over HTTP using Server-Sent Events (for web-based clients)
+mode = "stdio"
+
+# Only used when mode = "sse"
+# host = "127.0.0.1"
+# port = 3000
+
+# --------------------------------------------------------------------------
+# Connector — choose one
+# --------------------------------------------------------------------------
+
+# Option A: static JSON file
+[connector]
+type = "static"
+path = "examples/sample-newsletter.json"
+
+# --------------------------------------------------------------------------
+# Option B: one or more RSS/Atom feeds (comment out the static block above
+# and uncomment this section)
+# --------------------------------------------------------------------------
+
+# [connector]
+# type = "rss"
+#
+# [[connector.feeds]]
+# topic_id    = "rust"
+# topic_label = "Rust"
+# topic_description = "News from the Rust ecosystem"
+# topic_tags  = ["rust", "programming"]
+# url         = "https://blog.rust-lang.org/feed.xml"
+#
+# [[connector.feeds]]
+# topic_id    = "this-week-in-rust"
+# topic_label = "This Week in Rust"
+# topic_description = "Weekly Rust newsletter"
+# topic_tags  = ["rust", "community"]
+# url         = "https://this-week-in-rust.org/atom.xml"


### PR DESCRIPTION
## Summary

- Adds `crates/server/src/config.rs` with `Config`, `TransportConfig`, `TransportMode`, `ConnectorConfig`, and `FeedConfig` structs, full TOML parsing via `toml` 0.8, a `ConfigError` enum (thiserror), and a `load()` function with priority chain: `--config` CLI arg → `FERRISLETTER_CONFIG` env → `./ferrisletter.toml` → defaults
- Rewrites `crates/server/src/main.rs` to branch on `ConnectorConfig` variant (static / rss / fallback) and `TransportMode` (stdio / sse); backward-compat env var `FERRISLETTER_DATA` is preserved as final fallback
- Adds `examples/ferrisletter.toml` — annotated example config showing both static and RSS connector options with stdio / SSE transport

## Test plan

- [x] `cargo build -p ferrisletter-server` — clean
- [x] `cargo test -p ferrisletter-server` — 3 config unit tests pass (stdio+static, sse+rss, default transport)
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — no diff

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)