### PR TITLE
feat: add lefthook pre-push gate (#23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Ferrisletter
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) (stable, edition 2021)
+- [lefthook](https://github.com/evilmartians/lefthook) for git hooks
+
+## First-time setup
+
+```bash
+# Clone the repo
+git clone https://github.com/ferrislabs/ferrisletter.git
+cd ferrisletter
+
+# Install lefthook (macOS)
+brew install lefthook
+
+# Wire up the git hooks — run once per clone
+lefthook install
+```
+
+After `lefthook install`, a **pre-push** gate runs automatically before every `git push`:
+
+| Check | Command |
+|---|---|
+| Formatting | `cargo fmt --all -- --check` |
+| Lints | `cargo clippy --workspace -- -D warnings` |
+| Tests | `cargo test --workspace` |
+
+The gate only runs when `.rs` files are part of the push, so pure documentation or config-only changes don't trigger a full build.
+
+## Development workflow
+
+```bash
+# Build the workspace
+cargo build --workspace
+
+# Run all tests
+cargo test --workspace
+
+# Check lints
+cargo clippy --workspace -- -D warnings
+
+# Auto-fix formatting
+cargo fmt --all
+```
+
+## Project structure
+
+```
+crates/
+  connector/          # Connector trait + BoxedConnector (SDK)
+  connector-static/   # Static JSON connector
+  connector-rss/      # RSS/Atom connector
+  server/             # MCP server binary
+examples/             # Sample config and data files
+website/              # Ferrislabs marketing site (Astro)
+docs/                 # MCP client setup guides
+```
+
+## Opening a pull request
+
+1. Branch off `main`: `git checkout -b feat/your-feature`
+2. Make your changes and commit
+3. Push — the pre-push gate will run automatically
+4. Open a PR against `main` and fill in the template
+
+Please link the relevant GitHub issue in your PR description.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+# lefthook.yml — git hook configuration
+#
+# Setup (once per clone):
+#   brew install lefthook   # macOS
+#   lefthook install
+#
+# Docs: https://github.com/evilmartians/lefthook
+
+pre-push:
+  parallel: false
+  commands:
+    fmt:
+      glob: "**/*.rs"
+      run: cargo fmt --all -- --check
+      fail_text: "Run `cargo fmt --all` to fix formatting."
+
+    clippy:
+      glob: "**/*.rs"
+      run: cargo clippy --workspace -- -D warnings
+      fail_text: "Fix clippy warnings before pushing."
+
+    test:
+      glob: "**/*.rs"
+      run: cargo test --workspace
+      fail_text: "All tests must pass before pushing."


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` at repo root with a `pre-push` gate running three sequential checks:
  - `cargo fmt --all -- --check` — formatting
  - `cargo clippy --workspace -- -D warnings` — lints
  - `cargo test --workspace` — full test suite
- All three commands are glob-filtered on `**/*.rs` — pure doc/config pushes don't trigger a build
- Adds `CONTRIBUTING.md` documenting first-time setup (`lefthook install`), the pre-push gate, dev commands, and project structure

## Setup

```bash
brew install lefthook   # once per machine
lefthook install        # once per clone
```

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)