### PR TITLE
feat(meta): apply FerrisKey dev structure (#6)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS
+# Each line is a file pattern followed by one or more owners.
+# Order matters — the last matching rule takes precedence.
+
+# Default owner for everything
+* @luisRubiera
+
+# Connector SDK — changes here affect all connectors and the server
+/crates/connector/ @luisRubiera
+
+# Website
+/website/ @luisRubiera

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: "fix: "
+labels: "type:bug"
+assignees: ""
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behaviour:
+
+1. ...
+2. ...
+
+## Expected behaviour
+
+What you expected to happen.
+
+## Actual behaviour
+
+What actually happened. Include error messages, stack traces, or logs where relevant.
+
+## Environment
+
+- OS: <!-- e.g. macOS 14, Ubuntu 24.04 -->
+- Rust version: <!-- rustc --version -->
+- Ferrisletter version / commit: <!-- git rev-parse --short HEAD -->
+- Transport mode: <!-- stdio / sse -->
+- Connector type: <!-- static / rss -->
+
+## Additional context
+
+Add any other context, screenshots, or config snippets here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Propose a new feature or improvement
+title: "feat: "
+labels: "type:feature"
+assignees: ""
+---
+
+## Problem / motivation
+
+What problem does this feature solve? Who benefits and why does it matter?
+
+## Proposed solution
+
+Describe the solution you'd like. Be as specific as you can — API shape, config format, user-facing behaviour, etc.
+
+## Alternatives considered
+
+Any other approaches you explored and why you ruled them out.
+
+## Scope
+
+Which part of the codebase does this touch?
+
+- [ ] `scope:server` — MCP server / transport
+- [ ] `scope:connector` — connector SDK or a specific connector
+- [ ] `scope:website` — marketing site
+- [ ] `scope:ui` — React MCP app
+- [ ] Other: ___
+
+## Additional context
+
+Mockups, links, related issues, or anything else that helps.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- One sentence: what does this PR do and why? -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- Bullet list of what changed. Be specific — reviewers shouldn't need to read every line to understand the scope. -->
+
+-
+-
+
+## Test plan
+
+<!-- How did you verify this works? Check everything that applies. -->
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --workspace -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] Tested manually (describe how below)
+
+<!-- Manual testing notes -->
+
+## Notes for reviewer
+
+<!-- Anything the reviewer should pay special attention to, known trade-offs, or follow-up issues to open. Delete if not needed. -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ferrisletter
 
+[![CI](https://github.com/ferrislabs/ferrisletter/actions/workflows/ci.yml/badge.svg)](https://github.com/ferrislabs/ferrisletter/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Rust: 2024 edition](https://img.shields.io/badge/rust-2024%20edition-orange.svg)](https://doc.rust-lang.org/edition-guide/rust-2024/)
+
 **Newsletters that talk back.**
 
 A conversational newsletter platform powered by [MCP](https://modelcontextprotocol.io). Your LLM delivers the news — you just talk back. Built in Rust. Open source.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+## Overview
+
+Ferrisletter is a Rust workspace that exposes newsletter content as an MCP server. LLM clients (Claude Desktop, Cursor, Zed, etc.) connect to the server and interact with the content via five tools.
+
+```
+┌─────────────────────────────────────┐
+│           LLM Client                │
+│  (Claude Desktop / Cursor / Zed)    │
+└────────────────┬────────────────────┘
+                 │ MCP (stdio or SSE)
+┌────────────────▼────────────────────┐
+│         ferrisletter-server         │
+│                                     │
+│  FerrislletterServer (rmcp)         │
+│  ┌─────────────────────────────┐    │
+│  │       5 MCP tools           │    │
+│  │  list_topics · get_latest   │    │
+│  │  get_item · search · recap  │    │
+│  └──────────────┬──────────────┘    │
+│                 │ Connector trait   │
+│  ┌──────────────▼──────────────┐    │
+│  │       BoxedConnector        │    │
+│  └──────────────┬──────────────┘    │
+└─────────────────┼───────────────────┘
+          ┌───────┴────────┐
+          │                │
+   ┌──────▼──────┐  ┌──────▼──────┐
+   │   Static    │  │     RSS     │
+   │  Connector  │  │  Connector  │
+   │ (JSON file) │  │ (live feeds)│
+   └─────────────┘  └─────────────┘
+```
+
+## Crate layout
+
+| Crate | Role |
+|---|---|
+| `ferrisletter-connector` | `Connector` trait + `BoxedConnector` type-eraser (SDK) |
+| `ferrisletter-connector-static` | Loads content from a static JSON file |
+| `ferrisletter-connector-rss` | Aggregates one or more RSS/Atom feeds, with lazy cache |
+| `ferrisletter-server` | MCP server binary — wires transport, config, and connector |
+
+## Key design decisions
+
+### Connector trait (AFIT)
+
+The `Connector` trait uses **native async fn in trait** (Rust 2024 edition — no `async_trait` crate). Because AFIT traits are not object-safe, a `BoxedConnector` type-eraser is provided in the SDK crate. It uses an internal `ErasedConnector` trait with `BoxFuture` return types, allowing the server to hold `Arc<BoxedConnector>` without generics.
+
+### Transport
+
+The server supports two transports, selected via config:
+
+- **stdio** (default) — communicates over stdin/stdout; logs go to stderr. Works with any MCP client that spawns a child process.
+- **SSE** — serves over HTTP using Server-Sent Events. Used for remote/containerised deployments.
+
+### Configuration
+
+Config is resolved in priority order:
+
+1. `--config <path>` CLI argument
+2. `FERRISLETTER_CONFIG` environment variable
+3. `./ferrisletter.toml` in the working directory
+4. Built-in defaults (stdio + embedded sample data)
+
+See `examples/ferrisletter.toml` for an annotated reference.
+
+### RSS connector caching
+
+The RSS connector fetches all feeds once on first use and caches the result behind an `Arc<RwLock<Option<Vec<ItemDetail>>>>`. Subsequent calls hit the cache. The server process is expected to be short-lived (LLM client spawns it); for long-running SSE deployments, a TTL-based refresh should be added.
+
+## Data model
+
+```
+Topic          — id, label, description, tags
+Item           — id, topic_id, headline, summary, tags, source, published, read_time
+ItemDetail     — Item + body + links
+UserPrefs      — topic_ids (filter by topic)
+SearchFilters  — tags, since, topic_id
+```
+
+## MCP tools
+
+| Tool | Description |
+|---|---|
+| `ferrisletter_list_topics` | List all available topics |
+| `ferrisletter_get_latest` | Get latest items, optionally filtered by topic |
+| `ferrisletter_get_item` | Get full detail for a single item |
+| `ferrisletter_search` | Full-text + tag search across all items |
+| `ferrisletter_recap` | Get all items published since a given date |


### PR DESCRIPTION
## Summary

Closes #6

Aligns Ferrisletter's development tooling with FerrisKey conventions.

## Changes

- `.github/ISSUE_TEMPLATE/bug_report.md` — pre-filled labels, environment fields, reproduction steps
- `.github/ISSUE_TEMPLATE/feature_request.md` — scope checklist, motivation/alternatives structure
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, changes list, test plan checklist, reviewer notes
- `.github/CODEOWNERS` — `@luisRubiera` as default owner; connector SDK called out explicitly
- `docs/architecture.md` — full architecture overview: crate layout, connector trait design, transport, config priority chain, data model, MCP tools table
- `README.md` — CI badge, license badge, Rust edition badge
- Labels created: `type:bug`, `type:tests`, `type:refactor`

## Already covered in earlier PRs

- `CONTRIBUTING.md` — #24
- `lefthook` pre-push gate (fmt + clippy + test) — #24
- `RUSTFLAGS="-Dwarnings"` in CI — already present

## Test plan

- [x] No Rust changes — CI / fmt / clippy / test unaffected
- [x] Templates render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)