### PR TITLE
feat(ui): topic filter tabs + refresh; fix topic deduplication (#38, #39)

### DIFF
--- a/crates/connector-rss/src/lib.rs
+++ b/crates/connector-rss/src/lib.rs
@@ -125,9 +125,11 @@ impl RssConnector {
 
 impl Connector for RssConnector {
     async fn list_topics(&self) -> Result<Vec<Topic>, ConnectorError> {
+        let mut seen = std::collections::HashSet::new();
         Ok(self
             .feeds
             .iter()
+            .filter(|f| seen.insert(f.topic_id.clone()))
             .map(|f| Topic {
                 id: f.topic_id.clone(),
                 label: f.topic_label.clone(),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Loader2, WifiOff } from "lucide-react";
 import { CompactIssue } from "@/views/CompactIssue";
 import { connectMcp, listTopics, getLatestItems } from "@/lib/mcp";
 import { resolveServerUrl } from "@/lib/utils";
 import { DEMO_TOPICS, DEMO_ITEMS } from "@/lib/demo-data";
 import type { McpState } from "@/types";
+
+function dedupeTopics<T extends { id: string }>(topics: T[]): T[] {
+  const seen = new Set<string>();
+  return topics.filter((t) => seen.size < seen.add(t.id).size || !seen.has(t.id)
+    ? (seen.add(t.id), true)
+    : false
+  );
+}
 
 export default function App() {
   const [state, setState] = useState<McpState>({
@@ -13,46 +21,51 @@ export default function App() {
     items: [],
   });
 
-  useEffect(() => {
-    const serverUrl = resolveServerUrl();
+  const serverUrl = resolveServerUrl();
 
-    if (!serverUrl) {
-      // No server configured — show demo content.
-      setState({ status: "demo", topics: DEMO_TOPICS, items: DEMO_ITEMS });
-      return;
-    }
+  const load = useCallback(
+    async (isRefresh = false) => {
+      if (!serverUrl) {
+        setState({ status: "demo", topics: DEMO_TOPICS, items: DEMO_ITEMS });
+        return;
+      }
 
-    let cancelled = false;
+      setState((s) => ({
+        ...s,
+        status: isRefresh ? "connected" : "connecting",
+        refreshing: isRefresh,
+      }));
 
-    async function load() {
-      setState((s) => ({ ...s, status: "connecting" }));
       try {
-        await connectMcp(serverUrl!);
-        if (cancelled) return;
+        if (!isRefresh) await connectMcp(serverUrl);
 
         const [topics, items] = await Promise.all([
           listTopics(),
           getLatestItems(),
         ]);
-        if (cancelled) return;
 
-        setState({ status: "connected", topics, items });
+        setState({
+          status: "connected",
+          topics: dedupeTopics(topics),
+          items,
+          refreshing: false,
+        });
       } catch (err) {
-        if (cancelled) return;
         setState({
           status: "error",
           topics: [],
           items: [],
           error: err instanceof Error ? err.message : "Connection failed",
+          refreshing: false,
         });
       }
-    }
+    },
+    [serverUrl],
+  );
 
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  useEffect(() => {
+    void load(false);
+  }, [load]);
 
   if (state.status === "idle" || state.status === "connecting") {
     return (
@@ -83,6 +96,8 @@ export default function App() {
         topics={state.topics}
         items={state.items}
         isDemo={state.status === "demo"}
+        isRefreshing={!!(state as { refreshing?: boolean }).refreshing}
+        onRefresh={() => void load(true)}
       />
     </div>
   );

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -26,4 +26,5 @@ export interface McpState {
   topics: Topic[];
   items: Item[];
   error?: string;
+  refreshing?: boolean;
 }

--- a/ui/src/views/CompactIssue.tsx
+++ b/ui/src/views/CompactIssue.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { ChevronDown, ExternalLink, Clock, Loader2 } from "lucide-react";
+import { ChevronDown, ExternalLink, Clock, Loader2, RotateCw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn, formatDate } from "@/lib/utils";
 import { getItemDetail } from "@/lib/mcp";
@@ -51,7 +51,6 @@ function ItemRow({ item, isDemo }: ItemRowProps) {
           )}
           aria-expanded={open}
         >
-          {/* expand indicator */}
           <ChevronDown
             size={14}
             className={cn(
@@ -66,7 +65,7 @@ function ItemRow({ item, isDemo }: ItemRowProps) {
               {item.headline}
             </p>
             <div className="mt-1 flex items-center gap-2 flex-wrap">
-              <span className="text-xs text-[var(--color-text-dim)]">
+              <span className="text-xs text-[var(--color-text-dim)] truncate max-w-[160px]">
                 {item.source}
               </span>
               <span className="text-[var(--color-border-hover)]">·</span>
@@ -100,7 +99,6 @@ function ItemRow({ item, isDemo }: ItemRowProps) {
                 {body}
               </p>
 
-              {/* tags */}
               {item.tags.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-1">
                   {item.tags.map((tag) => (
@@ -111,7 +109,6 @@ function ItemRow({ item, isDemo }: ItemRowProps) {
                 </div>
               )}
 
-              {/* links */}
               {links.length > 0 && (
                 <div className="mt-3 flex flex-wrap gap-2">
                   {links.map((link) => (
@@ -149,7 +146,6 @@ function TopicSection({ topic, items, isDemo }: TopicSectionProps) {
 
   return (
     <section aria-labelledby={`topic-${topic.id}`}>
-      {/* topic header */}
       <div className="flex items-center gap-2 px-4 py-2 sticky top-0 bg-[var(--color-bg-card)] z-10 border-b border-[var(--color-border)]">
         <Badge variant="topic">{topic.label}</Badge>
         <span className="text-xs text-[var(--color-text-dim)]">
@@ -165,6 +161,48 @@ function TopicSection({ topic, items, isDemo }: TopicSectionProps) {
         ))}
       </ul>
     </section>
+  );
+}
+
+// ── Topic filter tabs ─────────────────────────────────────────────────────────
+
+interface TopicFilterProps {
+  topics: Topic[];
+  active: string | null;
+  onChange: (id: string | null) => void;
+}
+
+function TopicFilter({ topics, active, onChange }: TopicFilterProps) {
+  if (topics.length <= 1) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 px-4 py-2.5 border-b border-[var(--color-border)] overflow-x-auto shrink-0">
+      <button
+        onClick={() => onChange(null)}
+        className={cn(
+          "shrink-0 px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
+          active === null
+            ? "bg-[var(--color-accent)] text-white"
+            : "text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-elevated)]",
+        )}
+      >
+        All
+      </button>
+      {topics.map((t) => (
+        <button
+          key={t.id}
+          onClick={() => onChange(active === t.id ? null : t.id)}
+          className={cn(
+            "shrink-0 px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
+            active === t.id
+              ? "bg-[var(--color-accent)] text-white"
+              : "text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-elevated)]",
+          )}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -188,11 +226,27 @@ interface CompactIssueProps {
   topics: Topic[];
   items: Item[];
   isDemo: boolean;
+  isRefreshing: boolean;
+  onRefresh: () => void;
 }
 
-export function CompactIssue({ topics, items, isDemo }: CompactIssueProps) {
+export function CompactIssue({
+  topics,
+  items,
+  isDemo,
+  isRefreshing,
+  onRefresh,
+}: CompactIssueProps) {
+  const [activeTopicId, setActiveTopicId] = useState<string | null>(null);
+
+  const visibleTopics =
+    activeTopicId ? topics.filter((t) => t.id === activeTopicId) : topics;
+
   const byTopic = (topicId: string) =>
     items.filter((i) => i.topic_id === topicId);
+
+  const visibleItems =
+    activeTopicId ? items.filter((i) => i.topic_id === activeTopicId) : items;
 
   const latestDate =
     items.length > 0
@@ -215,16 +269,44 @@ export function CompactIssue({ topics, items, isDemo }: CompactIssueProps) {
             <p className="text-xs text-[var(--color-text-dim)]">{latestDate}</p>
           )}
         </div>
-        <Badge variant="muted">
-          {items.length} {items.length === 1 ? "item" : "items"}
-        </Badge>
+        <div className="flex items-center gap-2">
+          <Badge variant="muted">
+            {visibleItems.length}{" "}
+            {visibleItems.length === 1 ? "item" : "items"}
+          </Badge>
+          {!isDemo && (
+            <button
+              onClick={onRefresh}
+              disabled={isRefreshing}
+              aria-label="Refresh"
+              className={cn(
+                "p-1.5 rounded-md text-[var(--color-text-dim)] transition-colors",
+                "hover:text-[var(--color-text)] hover:bg-[var(--color-bg-elevated)]",
+                "disabled:opacity-40 disabled:cursor-not-allowed",
+              )}
+            >
+              <RotateCw
+                size={13}
+                className={isRefreshing ? "animate-spin" : ""}
+                aria-hidden
+              />
+            </button>
+          )}
+        </div>
       </header>
+
+      {/* topic filter */}
+      <TopicFilter
+        topics={topics}
+        active={activeTopicId}
+        onChange={setActiveTopicId}
+      />
 
       {/* scrollable content */}
       <div className="flex-1 overflow-y-auto">
         {isDemo && <DemoBanner />}
 
-        {topics.map((topic) => (
+        {visibleTopics.map((topic) => (
           <TopicSection
             key={topic.id}
             topic={topic}
@@ -233,7 +315,7 @@ export function CompactIssue({ topics, items, isDemo }: CompactIssueProps) {
           />
         ))}
 
-        {items.length === 0 && (
+        {visibleItems.length === 0 && (
           <div className="flex items-center justify-center h-32 text-sm text-[var(--color-text-dim)]">
             No items yet.
           </div>


### PR DESCRIPTION
## Summary

- **`fix`** `connector-rss`: `list_topics` now deduplicates by `topic_id` (first feed wins, insertion order preserved) — fixes the duplicate AI/Rust sections that appeared when multiple feeds shared a topic
- **`feat`** `ui`: topic filter pill row below the header — click any topic to scope the view; click again (or "All") to reset
- **`feat`** `ui`: refresh button (↺) in the header re-fetches topics + items without reconnecting the SSE transport
- **`fix`** `ui`: client-side dedup guard in `App.tsx` as belt-and-suspenders
- Item count badge in header updates live when a filter is active

## Test plan

- [ ] `ferrisletter_list_topics` with demo config returns 3 unique topics (AI, Rust, Open Source)
- [ ] Topic filter pills appear; clicking "Rust" hides AI + Open Source items
- [ ] Item count badge reflects filtered count
- [ ] Refresh button spins while loading, stops when done
- [ ] Demo mode (no `?server=`) still works with static data

Closes #38, #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)