### PR TITLE
feat(ui): search bar, results view with tag filter and sort

### DIFF
--- a/ui/src/components/ResultRow.tsx
+++ b/ui/src/components/ResultRow.tsx
@@ -1,0 +1,154 @@
+import { useState, useCallback } from "react";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { ChevronDown, ExternalLink, Clock, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn, formatDate } from "@/lib/utils";
+import { useMcpApp, getItemDetail } from "@/lib/mcp";
+import { highlightMatches } from "@/lib/search-utils";
+import type { Item, ItemDetail } from "@/types";
+
+interface ResultRowProps {
+  item: Item;
+  isDemo: boolean;
+  highlightQuery?: string;
+  onTagClick?: (tag: string) => void;
+}
+
+export function ResultRow({
+  item,
+  isDemo,
+  highlightQuery,
+  onTagClick,
+}: ResultRowProps) {
+  const app = useMcpApp();
+  const [open, setOpen] = useState(false);
+  const [detail, setDetail] = useState<ItemDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleOpen = useCallback(
+    async (next: boolean) => {
+      setOpen(next);
+      if (next && !detail && !isDemo && app) {
+        setLoading(true);
+        try {
+          const d = await getItemDetail(app, item.id);
+          setDetail(d);
+        } catch {
+          // fall back to summary
+        } finally {
+          setLoading(false);
+        }
+      }
+    },
+    [detail, isDemo, item.id, app],
+  );
+
+  const body = detail?.body ?? item.summary;
+  const links = detail?.links ?? [];
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={handleOpen}>
+      <Collapsible.Trigger asChild>
+        <button
+          className={cn(
+            "w-full text-left flex items-start gap-3 px-4 py-3 rounded-md",
+            "transition-colors hover:bg-[var(--color-bg-elevated)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]",
+            "group",
+          )}
+          aria-expanded={open}
+        >
+          <ChevronDown
+            size={14}
+            className={cn(
+              "mt-1 shrink-0 text-[var(--color-text-dim)] transition-transform duration-200",
+              open && "rotate-180",
+            )}
+            aria-hidden
+          />
+
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-[var(--color-text)] leading-snug">
+              {highlightQuery
+                ? highlightMatches(item.headline, highlightQuery)
+                : item.headline}
+            </p>
+            <div className="mt-1 flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-[var(--color-text-dim)] truncate max-w-[160px]">
+                {item.source}
+              </span>
+              <span className="text-[var(--color-border-hover)]">&middot;</span>
+              <span className="text-xs text-[var(--color-text-dim)]">
+                {formatDate(item.published)}
+              </span>
+              {item.read_time && (
+                <>
+                  <span className="text-[var(--color-border-hover)]">
+                    &middot;
+                  </span>
+                  <span className="flex items-center gap-1 text-xs text-[var(--color-text-dim)]">
+                    <Clock size={10} aria-hidden />
+                    {item.read_time}
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+        </button>
+      </Collapsible.Trigger>
+
+      <Collapsible.Content className="overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-up-2 data-[state=open]:slide-down-2">
+        <div className="px-4 pb-4 ml-[26px]">
+          {loading ? (
+            <div className="flex items-center gap-2 text-xs text-[var(--color-text-dim)] py-2">
+              <Loader2 size={12} className="animate-spin" aria-hidden />
+              Loading&hellip;
+            </div>
+          ) : (
+            <>
+              <p className="text-sm text-[var(--color-text-muted)] leading-relaxed">
+                {highlightQuery
+                  ? highlightMatches(body, highlightQuery)
+                  : body}
+              </p>
+
+              {item.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {item.tags.map((tag) => (
+                    <button
+                      key={tag}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onTagClick?.(tag);
+                      }}
+                      className="cursor-pointer"
+                    >
+                      <Badge variant="tag">{tag}</Badge>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {links.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {links.map((link) => (
+                    <a
+                      key={link.url}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors"
+                    >
+                      {link.label}
+                      <ExternalLink size={10} aria-hidden />
+                    </a>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}

--- a/ui/src/components/ResultsList.tsx
+++ b/ui/src/components/ResultsList.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { ResultRow } from "@/components/ResultRow";
+import { TagFilter } from "@/components/ui/tag-filter";
+import { SortControls } from "@/components/ui/sort-controls";
+import { sortItems } from "@/lib/search-utils";
+import type { Item, SortState } from "@/types";
+
+interface ResultsListProps {
+  items: Item[];
+  isDemo: boolean;
+  highlightQuery?: string;
+  activeTags: string[];
+  sort: SortState;
+  onTagToggle: (tag: string) => void;
+  onSortChange: (sort: SortState) => void;
+  onTagsClear: () => void;
+  emptyMessage?: string;
+}
+
+export function ResultsList({
+  items,
+  isDemo,
+  highlightQuery,
+  activeTags,
+  sort,
+  onTagToggle,
+  onSortChange,
+  onTagsClear,
+  emptyMessage = "No results.",
+}: ResultsListProps) {
+  const availableTags = useMemo(() => {
+    const tags = new Set<string>();
+    for (const item of items) {
+      for (const tag of item.tags) tags.add(tag);
+    }
+    return Array.from(tags).sort();
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    if (activeTags.length === 0) return items;
+    return items.filter((item) =>
+      activeTags.every((t) => item.tags.includes(t)),
+    );
+  }, [items, activeTags]);
+
+  const sorted = useMemo(() => sortItems(filtered, sort), [filtered, sort]);
+
+  return (
+    <div className="flex flex-col">
+      {/* toolbar */}
+      <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-[var(--color-border)]">
+        <TagFilter
+          availableTags={availableTags}
+          activeTags={activeTags}
+          onToggle={onTagToggle}
+          onClear={onTagsClear}
+        />
+        <SortControls sort={sort} onChange={onSortChange} />
+      </div>
+
+      {/* results */}
+      <div className="overflow-y-auto max-h-[500px]">
+        {sorted.length > 0 ? (
+          <ul role="list">
+            {sorted.map((item) => (
+              <li key={item.id}>
+                <ResultRow
+                  item={item}
+                  isDemo={isDemo}
+                  highlightQuery={highlightQuery}
+                  onTagClick={onTagToggle}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex items-center justify-center h-32 text-sm text-[var(--color-text-dim)]">
+            {emptyMessage}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/ui/search-bar.tsx
+++ b/ui/src/components/ui/search-bar.tsx
@@ -1,0 +1,58 @@
+import { Search, X, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+  placeholder?: string;
+  isLoading?: boolean;
+}
+
+export function SearchBar({
+  value,
+  onChange,
+  onClear,
+  placeholder = "Search articles...",
+  isLoading = false,
+}: SearchBarProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-2 rounded-md",
+        "bg-[var(--color-bg-elevated)] border border-[var(--color-border)]",
+        "focus-within:ring-2 focus-within:ring-[var(--color-accent)] focus-within:border-transparent",
+        "transition-[box-shadow,border-color]",
+      )}
+    >
+      <Search
+        size={14}
+        className="shrink-0 text-[var(--color-text-dim)]"
+        aria-hidden
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="flex-1 min-w-0 bg-transparent text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-dim)] outline-none"
+      />
+      {isLoading && (
+        <Loader2
+          size={14}
+          className="shrink-0 animate-spin text-[var(--color-text-dim)]"
+          aria-hidden
+        />
+      )}
+      {!isLoading && value && (
+        <button
+          onClick={onClear}
+          aria-label="Clear search"
+          className="shrink-0 p-0.5 rounded text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ui/sort-controls.tsx
+++ b/ui/src/components/ui/sort-controls.tsx
@@ -1,0 +1,48 @@
+import { ArrowUp, ArrowDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { SortState, SortField } from "@/types";
+
+interface SortControlsProps {
+  sort: SortState;
+  onChange: (sort: SortState) => void;
+}
+
+export function SortControls({ sort, onChange }: SortControlsProps) {
+  const handleClick = (field: SortField) => {
+    if (sort.field === field) {
+      onChange({ field, direction: sort.direction === "asc" ? "desc" : "asc" });
+    } else {
+      onChange({ field, direction: "desc" });
+    }
+  };
+
+  const Arrow = sort.direction === "asc" ? ArrowUp : ArrowDown;
+
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => handleClick("date")}
+        className={cn(
+          sort.field === "date" && "text-[var(--color-accent)]",
+        )}
+      >
+        Date
+        {sort.field === "date" && <Arrow size={10} aria-hidden />}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => handleClick("read_time")}
+        className={cn(
+          sort.field === "read_time" && "text-[var(--color-accent)]",
+        )}
+      >
+        Read time
+        {sort.field === "read_time" && <Arrow size={10} aria-hidden />}
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/components/ui/tag-filter.tsx
+++ b/ui/src/components/ui/tag-filter.tsx
@@ -1,0 +1,41 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface TagFilterProps {
+  availableTags: string[];
+  activeTags: string[];
+  onToggle: (tag: string) => void;
+  onClear: () => void;
+}
+
+export function TagFilter({
+  availableTags,
+  activeTags,
+  onToggle,
+  onClear,
+}: TagFilterProps) {
+  if (availableTags.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 overflow-x-auto py-1.5">
+      {activeTags.length > 0 && (
+        <button
+          onClick={onClear}
+          className={cn(
+            "shrink-0 text-[10px] font-medium text-[var(--color-text-dim)]",
+            "hover:text-[var(--color-text)] transition-colors",
+          )}
+        >
+          Clear
+        </button>
+      )}
+      {availableTags.map((tag) => (
+        <button key={tag} onClick={() => onToggle(tag)} className="shrink-0">
+          <Badge variant={activeTags.includes(tag) ? "topic" : "tag"}>
+            {tag}
+          </Badge>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/lib/hooks/useDebounce.ts
+++ b/ui/src/lib/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/ui/src/lib/mcp.ts
+++ b/ui/src/lib/mcp.ts
@@ -100,3 +100,32 @@ export async function getItemDetail(
   });
   return extractJson(result) as ItemDetail;
 }
+
+export async function searchItems(
+  app: App,
+  filters: {
+    query: string;
+    topics?: string[];
+    tags?: string[];
+    since?: string;
+    until?: string;
+    limit?: number;
+  },
+): Promise<Item[]> {
+  const result = await app.callServerTool({
+    name: "ferrisletter_search",
+    arguments: filters,
+  });
+  return extractJson(result) as Item[];
+}
+
+export async function recapItems(
+  app: App,
+  params: { since: string; topics?: string[]; max_items?: number },
+): Promise<Item[]> {
+  const result = await app.callServerTool({
+    name: "ferrisletter_recap",
+    arguments: params,
+  });
+  return extractJson(result) as Item[];
+}

--- a/ui/src/lib/search-utils.ts
+++ b/ui/src/lib/search-utils.ts
@@ -1,0 +1,61 @@
+import { createElement, type ReactNode } from "react";
+import type { Item, SortState } from "@/types";
+
+/** Case-insensitive local search across headline, summary, and tags. */
+export function filterItemsLocally(items: Item[], query: string): Item[] {
+  const q = query.toLowerCase().trim();
+  if (!q) return items;
+  return items.filter(
+    (item) =>
+      item.headline.toLowerCase().includes(q) ||
+      item.summary.toLowerCase().includes(q) ||
+      item.tags.some((tag) => tag.toLowerCase().includes(q)),
+  );
+}
+
+/** Extract numeric minutes from read_time strings like "4 min". */
+function parseReadTime(readTime: string): number {
+  const match = readTime.match(/(\d+)/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+/** Sort items by date or read_time. */
+export function sortItems(items: Item[], sort: SortState): Item[] {
+  const sorted = [...items];
+  sorted.sort((a, b) => {
+    let cmp: number;
+    if (sort.field === "date") {
+      cmp = new Date(a.published).getTime() - new Date(b.published).getTime();
+    } else {
+      cmp = parseReadTime(a.read_time) - parseReadTime(b.read_time);
+    }
+    return sort.direction === "asc" ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+/**
+ * Split text at case-insensitive query matches, wrapping matches in <mark>.
+ * Returns the original text unchanged if query is empty.
+ */
+export function highlightMatches(text: string, query: string): ReactNode[] {
+  if (!query.trim()) return [text];
+
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
+  const parts = text.split(regex);
+
+  return parts.map((part, i) =>
+    regex.test(part)
+      ? createElement(
+          "mark",
+          {
+            key: i,
+            className:
+              "bg-[var(--color-accent-glow)] text-[var(--color-text)] rounded-sm px-0.5",
+          },
+          part,
+        )
+      : part,
+  );
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -21,6 +21,18 @@ export interface ItemDetail extends Item {
   links: { url: string; label: string }[];
 }
 
+export type ViewMode = "digest" | "search" | "recap";
+export type SortField = "date" | "read_time";
+export type SortDirection = "asc" | "desc";
+export interface SortState {
+  field: SortField;
+  direction: SortDirection;
+}
+export interface RecapPreset {
+  label: string;
+  hours: number;
+}
+
 export interface McpState {
   status: "idle" | "connecting" | "connected" | "error" | "demo";
   topics: Topic[];

--- a/ui/src/views/SearchPanel.tsx
+++ b/ui/src/views/SearchPanel.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useRef } from "react";
+import { Search } from "lucide-react";
+import { SearchBar } from "@/components/ui/search-bar";
+import { ResultsList } from "@/components/ResultsList";
+import { useMcpApp, searchItems } from "@/lib/mcp";
+import { useDebounce } from "@/lib/hooks/useDebounce";
+import { filterItemsLocally } from "@/lib/search-utils";
+import { DEMO_ITEMS } from "@/lib/demo-data";
+import type { Item, Topic, SortState } from "@/types";
+
+interface SearchPanelProps {
+  topics: Topic[];
+  isDemo: boolean;
+}
+
+export function SearchPanel({ topics: _topics, isDemo }: SearchPanelProps) {
+  const app = useMcpApp();
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebounce(query, 300);
+  const [results, setResults] = useState<Item[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const [sort, setSort] = useState<SortState>({
+    field: "date",
+    direction: "desc",
+  });
+  const latestQueryRef = useRef(debouncedQuery);
+
+  useEffect(() => {
+    latestQueryRef.current = debouncedQuery;
+
+    if (!debouncedQuery.trim()) {
+      setResults([]);
+      setHasSearched(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function doSearch() {
+      setIsSearching(true);
+      try {
+        let items: Item[];
+        if (isDemo || !app) {
+          items = filterItemsLocally(DEMO_ITEMS, debouncedQuery);
+        } else {
+          items = await searchItems(app, { query: debouncedQuery });
+        }
+        // Discard stale results
+        if (!cancelled && latestQueryRef.current === debouncedQuery) {
+          setResults(items);
+          setHasSearched(true);
+        }
+      } catch {
+        if (!cancelled) {
+          setResults([]);
+          setHasSearched(true);
+        }
+      } finally {
+        if (!cancelled) setIsSearching(false);
+      }
+    }
+
+    void doSearch();
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery, isDemo, app]);
+
+  const handleTagToggle = (tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  };
+
+  const handleClear = () => {
+    setQuery("");
+    setResults([]);
+    setHasSearched(false);
+    setActiveTags([]);
+  };
+
+  return (
+    <div className="flex flex-col bg-[var(--color-bg-card)] rounded-lg border border-[var(--color-border)] overflow-hidden">
+      {/* header */}
+      <header className="px-4 py-3 border-b border-[var(--color-border)] shrink-0">
+        <h2 className="text-sm font-semibold text-[var(--color-text)] tracking-tight mb-2">
+          Search
+        </h2>
+        <SearchBar
+          value={query}
+          onChange={setQuery}
+          onClear={handleClear}
+          isLoading={isSearching}
+        />
+      </header>
+
+      {/* content */}
+      {hasSearched ? (
+        <ResultsList
+          items={results}
+          isDemo={isDemo}
+          highlightQuery={debouncedQuery}
+          activeTags={activeTags}
+          sort={sort}
+          onTagToggle={handleTagToggle}
+          onSortChange={setSort}
+          onTagsClear={() => setActiveTags([])}
+          emptyMessage={`No results for "${debouncedQuery}"`}
+        />
+      ) : (
+        <div className="flex flex-col items-center justify-center h-32 gap-2 text-[var(--color-text-dim)]">
+          <Search size={20} aria-hidden />
+          <p className="text-sm">Search articles by keyword&hellip;</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- SearchBar with debounced input, clear button, and loading state
- ResultsList with tag-based filtering and sort controls (date/read_time)
- ResultRow with term highlighting in headlines and clickable tag badges
- SearchPanel view with demo-mode local search fallback
- MCP tool helpers: `searchItems()` and `recapItems()`

Closes #50, #51, #52, #53

## Test plan
- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] Vite build succeeds
- [x] Search renders in demo mode with highlighted results
- [x] Tag filter narrows results, sort toggles work
- [x] All pre-push hooks pass (clippy, fmt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)