### PR TITLE
feat(website): add Features, Themes, Connect, and Docs pages

### DIFF
--- a/website/src/components/CTA.tsx
+++ b/website/src/components/CTA.tsx
@@ -12,76 +12,40 @@ export default function CTA() {
   }, []);
 
   return (
-    <>
-      <section className="py-28 pb-24 relative z-[1]" ref={ref}>
-        <div className="absolute w-[500px] h-[500px] bottom-0 left-1/2 -translate-x-1/2 rounded-full bg-[var(--color-accent)] opacity-[0.06] blur-[120px] pointer-events-none" />
-        <div
-          className={`max-w-[800px] mx-auto px-8 transition-all duration-700 ease-out ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}
-        >
-          <div className="text-center p-16 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-3xl relative overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-br from-[rgba(109,90,255,0.05)] via-transparent to-[rgba(34,211,238,0.03)] pointer-events-none" />
-            <span className="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-6 relative">
-              Early access
-            </span>
-            <h2 className="text-[clamp(1.8rem,4vw,2.8rem)] font-extrabold tracking-tight leading-tight mb-4 relative">
-              The future of newsletters
-              <br />
-              is a conversation.
-            </h2>
-            <p className="text-base text-[var(--color-text-muted)] max-w-[480px] mx-auto mb-8 leading-relaxed relative">
-              Ferrisletter is open source and under active development. Star the repo, join the community, or contribute.
-            </p>
-            <div className="flex gap-4 justify-center flex-wrap relative">
-              <a
-                href="https://github.com/ferrislabs/ferrisletter"
-                target="_blank"
-                rel="noopener"
-                className="inline-flex items-center gap-2 px-10 py-3.5 bg-[var(--color-accent)] text-white rounded-xl text-base font-semibold hover:bg-[var(--color-accent-hover)] hover:-translate-y-0.5 hover:shadow-[0_8px_30px_rgba(109,90,255,0.3)] transition-all"
-              >
-                Star on GitHub
-              </a>
-              <a
-                href="https://discord.gg/a5mynqNgtU"
-                target="_blank"
-                rel="noopener"
-                className="inline-flex items-center gap-2 px-10 py-3.5 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-xl text-base font-semibold hover:border-[var(--color-border-hover)] hover:-translate-y-0.5 transition-all"
-              >
-                Join Discord
-              </a>
-            </div>
+    <section className="py-28 pb-24 relative z-[1]" ref={ref}>
+      <div className="absolute w-[500px] h-[500px] bottom-0 left-1/2 -translate-x-1/2 rounded-full bg-[var(--color-accent)] opacity-[0.06] blur-[120px] pointer-events-none" />
+      <div
+        className={`max-w-[800px] mx-auto px-8 transition-all duration-700 ease-out ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}
+      >
+        <div className="text-center p-16 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-3xl relative overflow-hidden">
+          <div className="absolute inset-0 bg-gradient-to-br from-[rgba(109,90,255,0.05)] via-transparent to-[rgba(34,211,238,0.03)] pointer-events-none" />
+          <span className="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-6 relative">
+            Early access
+          </span>
+          <h2 className="text-[clamp(1.8rem,4vw,2.8rem)] font-extrabold tracking-tight leading-tight mb-4 relative">
+            The future of newsletters
+            <br />
+            is a conversation.
+          </h2>
+          <p className="text-base text-[var(--color-text-muted)] max-w-[480px] mx-auto mb-8 leading-relaxed relative">
+            Ferrisletter is open source and under active development. Star the repo, join the community, or contribute.
+          </p>
+          <div className="flex gap-4 justify-center flex-wrap relative">
+            <a
+              href="/connect"
+              className="inline-flex items-center gap-2 px-10 py-3.5 bg-[var(--color-accent)] text-white rounded-xl text-base font-semibold hover:bg-[var(--color-accent-hover)] hover:-translate-y-0.5 hover:shadow-[0_8px_30px_rgba(109,90,255,0.3)] transition-all"
+            >
+              Get Connected
+            </a>
+            <a
+              href="/features"
+              className="inline-flex items-center gap-2 px-10 py-3.5 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-xl text-base font-semibold hover:border-[var(--color-border-hover)] hover:-translate-y-0.5 transition-all"
+            >
+              Explore Features
+            </a>
           </div>
         </div>
-      </section>
-
-      <footer className="py-8 border-t border-[var(--color-border)] relative z-[1]">
-        <div className="max-w-[1200px] mx-auto px-8 flex items-center justify-between max-sm:flex-col max-sm:gap-3 max-sm:text-center">
-          <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-2 font-bold text-base">
-              <span className="text-[var(--color-accent)]">&#9671;</span>
-              <span>ferrisletter</span>
-            </div>
-            <span className="text-[0.65rem] text-[var(--color-text-dim)] pl-5">
-              a{' '}
-              <a
-                href="https://github.com/ferrislabs"
-                target="_blank"
-                rel="noopener"
-                className="hover:text-[var(--color-text-muted)] transition-colors"
-              >
-                Ferrislabs
-              </a>
-              {' '}project
-            </span>
-          </div>
-          <div className="flex items-center gap-4">
-            <a href="https://github.com/ferrislabs/ferrisletter" target="_blank" rel="noopener" className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors">GitHub</a>
-            <span className="text-[var(--color-border)]">&middot;</span>
-            <a href="https://discord.gg/a5mynqNgtU" target="_blank" rel="noopener" className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] transition-colors">Discord</a>
-            <span className="text-[var(--color-border)]">&middot;</span>
-            <span className="text-xs text-[var(--color-text-dim)]">Built with Rust</span>
-          </div>
-        </div>
-      </footer>
-    </>
+      </div>
+    </section>
   );
 }

--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface Props {
+  code: string;
+  filename?: string;
+}
+
+export default function CodeBlock({ code, filename }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl overflow-hidden">
+      {filename && (
+        <div className="px-4 py-2.5 border-b border-[var(--color-border)] flex items-center justify-between">
+          <span className="font-mono text-xs text-[var(--color-text-dim)]">{filename}</span>
+          <button
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)] transition-all"
+            aria-label="Copy to clipboard"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      )}
+      <div className="relative">
+        {!filename && (
+          <button
+            onClick={handleCopy}
+            className="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg)] transition-all"
+            aria-label="Copy to clipboard"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        )}
+        <pre className="p-4 overflow-x-auto font-mono text-sm text-[var(--color-text-muted)] leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/DocsSidebar.tsx
+++ b/website/src/components/DocsSidebar.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+
+interface Props {
+  currentPath: string;
+}
+
+const sections = [
+  {
+    title: 'Getting Started',
+    items: [
+      { label: 'Overview', href: '/docs' },
+      { label: 'Getting Started', href: '/docs/getting-started' },
+      { label: 'Connect to Claude', href: '/docs/connect-claude' },
+    ],
+  },
+  {
+    title: 'Configuration',
+    items: [
+      { label: 'Display Preferences', href: '/docs/display-preferences' },
+      { label: 'Scheduled Delivery', href: '/docs/scheduled-delivery' },
+    ],
+  },
+  {
+    title: 'Advanced',
+    items: [
+      { label: 'Building Connectors', href: '/docs/building-connectors' },
+    ],
+  },
+];
+
+function isActive(currentPath: string, href: string) {
+  const clean = currentPath.replace(/\/$/, '') || '/';
+  const target = href.replace(/\/$/, '') || '/';
+  return clean === target;
+}
+
+export default function DocsSidebar({ currentPath }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const nav = (
+    <nav className="space-y-6">
+      {sections.map((section) => (
+        <div key={section.title}>
+          <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-2 block">
+            {section.title}
+          </span>
+          <ul className="space-y-1">
+            {section.items.map((item) => (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  className={`block px-3 py-1.5 rounded-md text-sm transition-colors ${
+                    isActive(currentPath, item.href)
+                      ? 'text-[var(--color-accent)] bg-[var(--color-accent-glow)] font-medium border-l-2 border-[var(--color-accent)]'
+                      : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-elevated)]'
+                  }`}
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+
+  return (
+    <>
+      {/* Desktop: always visible */}
+      <div className="hidden md:block sticky top-28">
+        {nav}
+      </div>
+
+      {/* Mobile: collapsible */}
+      <div className="md:hidden">
+        <button
+          onClick={() => setOpen(!open)}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--color-bg-elevated)] border border-[var(--color-border)] text-sm font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors w-full"
+        >
+          {open ? <X size={16} /> : <Menu size={16} />}
+          Docs Menu
+        </button>
+        {open && (
+          <div className="mt-3 p-4 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl">
+            {nav}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,0 +1,43 @@
+---
+---
+
+<footer class="py-10 border-t border-[var(--color-border)] relative z-[1]">
+  <div class="max-w-[1200px] mx-auto px-8">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-8 mb-8">
+      <!-- Branding -->
+      <div class="flex flex-col gap-1">
+        <div class="flex items-center gap-2 font-bold text-base">
+          <span class="text-[var(--color-accent)]">&#9671;</span>
+          <span>ferrisletter</span>
+        </div>
+        <span class="text-[0.65rem] text-[var(--color-text-dim)] pl-5">
+          a <a href="https://github.com/ferrislabs" target="_blank" rel="noopener" class="hover:text-[var(--color-text-muted)] transition-colors">Ferrislabs</a> project
+        </span>
+      </div>
+
+      <!-- Page links -->
+      <div class="flex flex-col gap-2">
+        <span class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-1">Pages</span>
+        <a href="/" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Home</a>
+        <a href="/features" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Features</a>
+        <a href="/themes" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Themes</a>
+        <a href="/docs" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Docs</a>
+        <a href="/connect" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Connect</a>
+      </div>
+
+      <!-- External links -->
+      <div class="flex flex-col gap-2">
+        <span class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-1">Community</span>
+        <a href="https://github.com/ferrislabs/ferrisletter" target="_blank" rel="noopener" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">GitHub</a>
+        <a href="https://discord.gg/a5mynqNgtU" target="_blank" rel="noopener" class="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">Discord</a>
+      </div>
+    </div>
+
+    <div class="pt-6 border-t border-[var(--color-border)] flex items-center justify-between max-sm:flex-col max-sm:gap-2 max-sm:text-center">
+      <span class="text-xs text-[var(--color-text-dim)]">Built with Rust</span>
+      <span class="text-xs text-[var(--color-text-dim)]">
+        Powered by <a href="https://www.cloud-iam.com" target="_blank" rel="noopener" class="hover:text-[var(--color-text-muted)] transition-colors">Cloud-IAM</a>
+      </span>
+    </div>
+  </div>
+</footer>

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react';
+import { Menu, X } from 'lucide-react';
+
+const links = [
+  { label: 'Features', href: '/features' },
+  { label: 'Themes', href: '/themes' },
+  { label: 'Docs', href: '/docs' },
+];
 
 export default function Nav() {
   const [scrolled, setScrolled] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 50);
@@ -9,45 +17,111 @@ export default function Nav() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => { document.body.style.overflow = ''; };
+  }, [mobileOpen]);
+
   return (
-    <nav
-      className={`fixed top-0 left-0 right-0 z-100 px-8 py-4 transition-all duration-250 ${
-        scrolled ? 'bg-[var(--color-bg)]/80 backdrop-blur-xl border-b border-[var(--color-border)]' : ''
-      }`}
-    >
-      <div className="max-w-[1200px] mx-auto flex items-center justify-between">
-        <a href="/" className="flex items-center gap-2 font-bold text-lg tracking-tight">
-          <span className="text-[var(--color-accent)] text-xl">&#9671;</span>
-          <span>ferrisletter</span>
-        </a>
-        <div className="flex items-center gap-8">
-          <a href="#how-it-works" className="hidden sm:inline text-[var(--color-text-muted)] text-sm font-medium hover:text-[var(--color-text)] transition-colors">
-            How it works
+    <>
+      <nav
+        className={`fixed top-0 left-0 right-0 z-100 px-8 py-4 transition-all duration-250 ${
+          scrolled ? 'bg-[var(--color-bg)]/80 backdrop-blur-xl border-b border-[var(--color-border)]' : ''
+        }`}
+      >
+        <div className="max-w-[1200px] mx-auto flex items-center justify-between">
+          <a href="/" className="flex items-center gap-2 font-bold text-lg tracking-tight">
+            <span className="text-[var(--color-accent)] text-xl">&#9671;</span>
+            <span>ferrisletter</span>
           </a>
-          <a href="#features" className="hidden sm:inline text-[var(--color-text-muted)] text-sm font-medium hover:text-[var(--color-text)] transition-colors">
-            Features
-          </a>
-          <a href="#stack" className="hidden sm:inline text-[var(--color-text-muted)] text-sm font-medium hover:text-[var(--color-text)] transition-colors">
-            Stack
-          </a>
-          <a
-            href="https://discord.gg/a5mynqNgtU"
-            target="_blank"
-            rel="noopener"
-            className="text-[var(--color-text-muted)] text-sm font-medium hover:text-[var(--color-text)] transition-colors hidden sm:inline"
+
+          {/* Desktop links */}
+          <div className="hidden md:flex items-center gap-8">
+            {links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="text-[var(--color-text-muted)] text-sm font-medium hover:text-[var(--color-text)] transition-colors"
+              >
+                {link.label}
+              </a>
+            ))}
+            <a
+              href="https://github.com/ferrislabs/ferrisletter"
+              target="_blank"
+              rel="noopener"
+              className="inline-flex items-center gap-2 px-5 py-2 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-lg text-sm font-medium hover:border-[var(--color-border-hover)] transition-all"
+            >
+              GitHub <span>&rarr;</span>
+            </a>
+            <a
+              href="/connect"
+              className="inline-flex items-center gap-2 px-5 py-2 bg-[var(--color-accent)] text-white rounded-lg text-sm font-semibold hover:bg-[var(--color-accent-hover)] transition-all"
+            >
+              Connect
+            </a>
+          </div>
+
+          {/* Mobile hamburger */}
+          <button
+            className="md:hidden p-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open menu"
           >
-            Discord
-          </a>
-          <a
-            href="https://github.com/ferrislabs/ferrisletter"
-            target="_blank"
-            rel="noopener"
-            className="inline-flex items-center gap-2 px-5 py-2 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-lg text-sm font-medium hover:border-[var(--color-border-hover)] transition-all"
-          >
-            GitHub <span>&rarr;</span>
-          </a>
+            <Menu size={24} />
+          </button>
         </div>
-      </div>
-    </nav>
+      </nav>
+
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <div className="fixed inset-0 z-200 bg-[var(--color-bg)]/95 backdrop-blur-xl">
+          <div className="flex items-center justify-between px-8 py-4">
+            <a href="/" className="flex items-center gap-2 font-bold text-lg tracking-tight">
+              <span className="text-[var(--color-accent)] text-xl">&#9671;</span>
+              <span>ferrisletter</span>
+            </a>
+            <button
+              className="p-2 text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+              onClick={() => setMobileOpen(false)}
+              aria-label="Close menu"
+            >
+              <X size={24} />
+            </button>
+          </div>
+          <div className="flex flex-col items-center gap-6 pt-16">
+            {links.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="text-xl font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+                onClick={() => setMobileOpen(false)}
+              >
+                {link.label}
+              </a>
+            ))}
+            <a
+              href="https://github.com/ferrislabs/ferrisletter"
+              target="_blank"
+              rel="noopener"
+              className="text-xl font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+            >
+              GitHub
+            </a>
+            <a
+              href="/connect"
+              className="mt-4 inline-flex items-center gap-2 px-8 py-3 bg-[var(--color-accent)] text-white rounded-xl text-lg font-semibold hover:bg-[var(--color-accent-hover)] transition-all"
+              onClick={() => setMobileOpen(false)}
+            >
+              Connect
+            </a>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/website/src/components/PageHeader.astro
+++ b/website/src/components/PageHeader.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+  tag: string;
+  title: string;
+  subtitle?: string;
+}
+
+const { tag, title, subtitle } = Astro.props;
+---
+
+<div class="text-center mb-16 pt-32 pb-4">
+  <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-4">
+    {tag}
+  </span>
+  <h1 class="text-[clamp(2rem,5vw,3.2rem)] font-extrabold tracking-tight leading-tight mb-4">
+    {title}
+  </h1>
+  {subtitle && (
+    <p class="text-base text-[var(--color-text-muted)] max-w-[560px] mx-auto leading-relaxed">
+      {subtitle}
+    </p>
+  )}
+</div>

--- a/website/src/components/ThemeGallery.tsx
+++ b/website/src/components/ThemeGallery.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+
+interface ThemeDef {
+  id: string;
+  name: string;
+  tagline: string;
+  colors: {
+    bg: string;
+    cardBg: string;
+    text: string;
+    muted: string;
+    dim: string;
+    accent: string;
+    accentSecondary: string;
+    border: string;
+    tagBg: string;
+    tagBorder: string;
+  };
+  font?: string;
+  tight?: boolean;
+  headlinesOnly?: boolean;
+}
+
+const themes: ThemeDef[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    tagline: 'Perfect for late-night reading.',
+    colors: {
+      bg: '#09090b', cardBg: '#18181b', text: '#fafafa', muted: '#a1a1aa', dim: '#71717a',
+      accent: '#6d5aff', accentSecondary: '#22d3ee', border: '#27272a',
+      tagBg: 'rgba(109,90,255,0.1)', tagBorder: 'rgba(109,90,255,0.25)',
+    },
+  },
+  {
+    id: 'light',
+    name: 'Light',
+    tagline: 'Ideal for daytime use.',
+    colors: {
+      bg: '#ffffff', cardBg: '#f4f4f5', text: '#09090b', muted: '#52525b', dim: '#71717a',
+      accent: '#6d5aff', accentSecondary: '#0891b2', border: '#e4e4e7',
+      tagBg: 'rgba(109,90,255,0.08)', tagBorder: 'rgba(109,90,255,0.2)',
+    },
+  },
+  {
+    id: 'daltonian',
+    name: 'Daltonian',
+    tagline: 'Accessible to everyone.',
+    colors: {
+      bg: '#0a0a0f', cardBg: '#151520', text: '#e8e8f0', muted: '#9898a8', dim: '#686878',
+      accent: '#4cc9f0', accentSecondary: '#f77f00', border: '#252535',
+      tagBg: 'rgba(76,201,240,0.1)', tagBorder: 'rgba(76,201,240,0.25)',
+    },
+  },
+  {
+    id: 'high-contrast',
+    name: 'High Contrast',
+    tagline: 'Maximum readability.',
+    colors: {
+      bg: '#000000', cardBg: '#0a0a0a', text: '#ffffff', muted: '#d4d4d4', dim: '#a0a0a0',
+      accent: '#ffff00', accentSecondary: '#00ffff', border: '#444444',
+      tagBg: 'rgba(255,255,0,0.1)', tagBorder: 'rgba(255,255,0,0.3)',
+    },
+  },
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    tagline: 'Zero noise.',
+    colors: {
+      bg: '#0a0a0a', cardBg: '#111111', text: '#d4d4d4', muted: '#888888', dim: '#666666',
+      accent: '#999999', accentSecondary: '#999999', border: '#222222',
+      tagBg: 'rgba(153,153,153,0.1)', tagBorder: 'rgba(153,153,153,0.2)',
+    },
+    font: "'JetBrains Mono', monospace",
+    tight: true,
+    headlinesOnly: true,
+  },
+];
+
+export default function ThemeGallery() {
+  const [activeId, setActiveId] = useState('default');
+  const theme = themes.find((t) => t.id === activeId)!;
+
+  return (
+    <div>
+      {/* Tab bar */}
+      <div className="flex gap-1 justify-center mb-3 flex-wrap">
+        {themes.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setActiveId(t.id)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+              t.id === activeId
+                ? 'bg-[var(--color-accent)] text-white'
+                : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-elevated)]'
+            }`}
+          >
+            {t.name}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-center text-sm text-[var(--color-text-muted)] mb-8">{theme.tagline}</p>
+
+      {/* Preview card */}
+      <div className="max-w-[640px] mx-auto">
+        <div
+          className="rounded-2xl border overflow-hidden transition-all duration-300"
+          style={{
+            backgroundColor: theme.colors.bg,
+            borderColor: theme.colors.border,
+            fontFamily: theme.font || "'Inter', sans-serif",
+            color: theme.colors.text,
+          }}
+        >
+          {/* Header */}
+          <div
+            className="px-6 py-4 flex items-center justify-between border-b"
+            style={{ borderColor: theme.colors.border }}
+          >
+            <span className="font-semibold text-sm" style={{ color: theme.colors.accent }}>
+              Lattice Digest
+            </span>
+            <span className="text-xs" style={{ color: theme.colors.dim }}>
+              April 6, 2026 &middot; 5 items
+            </span>
+          </div>
+
+          {/* Content */}
+          <div className={`px-6 ${theme.tight ? 'py-3' : 'py-5'} space-y-${theme.tight ? '2' : '4'}`}>
+            {/* Topic: Rust */}
+            <div>
+              <span
+                className="inline-block text-[0.65rem] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full mb-2"
+                style={{
+                  color: theme.colors.accent,
+                  backgroundColor: theme.colors.tagBg,
+                  border: `1px solid ${theme.colors.tagBorder}`,
+                }}
+              >
+                Rust
+              </span>
+              <div className={theme.tight ? 'space-y-1' : 'space-y-3'}>
+                <div>
+                  <p className={`font-semibold ${theme.tight ? 'text-xs' : 'text-sm'}`}>
+                    <a href="#" style={{ color: theme.colors.text }} className="hover:underline">
+                      Rust 1.94 ships async closures
+                    </a>
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: theme.colors.dim }}>
+                    blog.rust-lang.org &middot; Apr 5 &middot; 4 min
+                  </p>
+                  {!theme.headlinesOnly && (
+                    <p className="text-xs mt-1" style={{ color: theme.colors.muted }}>
+                      Async closures hit stable, eliminating a major pain point for async code.
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <p className={`font-semibold ${theme.tight ? 'text-xs' : 'text-sm'}`}>
+                    <a href="#" style={{ color: theme.colors.text }} className="hover:underline">
+                      cargo-semver-checks reaches 1.0
+                    </a>
+                  </p>
+                  <p className="text-xs mt-0.5" style={{ color: theme.colors.dim }}>
+                    github.com &middot; Apr 4 &middot; 2 min
+                  </p>
+                  {!theme.headlinesOnly && (
+                    <p className="text-xs mt-1" style={{ color: theme.colors.muted }}>
+                      The Rust ecosystem's semver linter is now stable and ready for CI.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Topic: AI */}
+            <div
+              className="pt-3 border-t"
+              style={{ borderColor: theme.colors.border }}
+            >
+              <span
+                className="inline-block text-[0.65rem] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full mb-2"
+                style={{
+                  color: theme.colors.accentSecondary,
+                  backgroundColor: theme.id === 'minimal' ? theme.colors.tagBg : `${theme.colors.accentSecondary}15`,
+                  border: `1px solid ${theme.id === 'minimal' ? theme.colors.tagBorder : `${theme.colors.accentSecondary}40`}`,
+                }}
+              >
+                AI
+              </span>
+              <div>
+                <p className={`font-semibold ${theme.tight ? 'text-xs' : 'text-sm'}`}>
+                  <a href="#" style={{ color: theme.colors.text }} className="hover:underline">
+                    MCP Apps spec reaches v1.0
+                  </a>
+                </p>
+                <p className="text-xs mt-0.5" style={{ color: theme.colors.dim }}>
+                  modelcontextprotocol.io &middot; Apr 6 &middot; 3 min
+                </p>
+                {!theme.headlinesOnly && (
+                  <p className="text-xs mt-1" style={{ color: theme.colors.muted }}>
+                    The Model Context Protocol's interactive UI extension is now finalized.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -1,0 +1,85 @@
+---
+import Layout from './Layout.astro';
+import Nav from '../components/Nav';
+import DocsSidebar from '../components/DocsSidebar';
+import Footer from '../components/Footer.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+const currentPath = Astro.url.pathname;
+---
+
+<Layout title={`${title} — Ferrisletter Docs`} description={description}>
+  <Nav client:load />
+  <div class="max-w-[1200px] mx-auto px-8 pt-28 pb-20">
+    <div class="flex gap-12">
+      <aside class="hidden md:block w-[240px] shrink-0">
+        <DocsSidebar currentPath={currentPath} client:load />
+      </aside>
+      <main class="flex-1 min-w-0 docs-content">
+        <div class="md:hidden mb-8">
+          <DocsSidebar currentPath={currentPath} client:load />
+        </div>
+        <slot />
+      </main>
+    </div>
+  </div>
+  <Footer />
+</Layout>
+
+<style is:global>
+  .docs-content h1 {
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.5rem;
+  }
+  .docs-content h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+  }
+  .docs-content h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+  .docs-content p {
+    color: var(--color-text-muted);
+    line-height: 1.7;
+    margin-bottom: 1rem;
+  }
+  .docs-content ul, .docs-content ol {
+    color: var(--color-text-muted);
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    line-height: 1.7;
+  }
+  .docs-content ul { list-style-type: disc; }
+  .docs-content ol { list-style-type: decimal; }
+  .docs-content li { margin-bottom: 0.5rem; }
+  .docs-content code:not(pre code) {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8em;
+    background: var(--color-bg-elevated);
+    padding: 0.15em 0.4em;
+    border-radius: 0.25rem;
+  }
+  .docs-content a {
+    color: var(--color-accent);
+    transition: color 0.15s;
+  }
+  .docs-content a:hover {
+    color: var(--color-accent-hover);
+  }
+  .docs-content strong {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+</style>

--- a/website/src/pages/connect.astro
+++ b/website/src/pages/connect.astro
@@ -1,0 +1,127 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Nav from '../components/Nav';
+import PageHeader from '../components/PageHeader.astro';
+import CodeBlock from '../components/CodeBlock';
+import Footer from '../components/Footer.astro';
+
+const configJson = `{
+  "mcpServers": {
+    "lattice": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://mcp.ferrisletter.dev/mcp"]
+    }
+  }
+}`;
+---
+
+<Layout title="Connect — Ferrisletter" description="Get connected to Ferrisletter in 30 seconds with a simple config snippet.">
+  <Nav client:load />
+  <div class="max-w-[800px] mx-auto px-8">
+    <PageHeader
+      tag="Connect"
+      title="Connect to Ferrisletter in 30 seconds"
+      subtitle="Add Lattice to Claude Desktop with a single config snippet. No install, no build, no signup."
+    />
+
+    <!-- Prerequisites -->
+    <section class="mb-12" data-reveal>
+      <h2 class="text-xl font-bold tracking-tight mb-4">Prerequisites</h2>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl p-5">
+        <ul class="space-y-2 text-sm text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2">
+            <span class="text-[var(--color-accent)] mt-0.5">&#10003;</span>
+            <span><strong class="text-[var(--color-text)]">Node.js 18+</strong> — needed for npx to run mcp-remote</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="text-[var(--color-accent)] mt-0.5">&#10003;</span>
+            <span><strong class="text-[var(--color-text)]">Claude Desktop</strong> — Pro, Max, Team, or Enterprise plan</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Config snippet -->
+    <section class="mb-12" data-reveal>
+      <h2 class="text-xl font-bold tracking-tight mb-4">1. Copy the config</h2>
+      <CodeBlock code={configJson} filename="claude_desktop_config.json" client:load />
+    </section>
+
+    <!-- Config file location -->
+    <section class="mb-12" data-reveal>
+      <h2 class="text-xl font-bold tracking-tight mb-4">2. Open your config file</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl p-5">
+          <span class="inline-block text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-2">macOS</span>
+          <code class="block font-mono text-xs text-[var(--color-text-muted)] break-all">~/Library/Application Support/Claude/claude_desktop_config.json</code>
+        </div>
+        <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl p-5">
+          <span class="inline-block text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-2">Windows</span>
+          <code class="block font-mono text-xs text-[var(--color-text-muted)] break-all">%APPDATA%\Claude\claude_desktop_config.json</code>
+        </div>
+      </div>
+    </section>
+
+    <!-- Steps -->
+    <section class="mb-12" data-reveal>
+      <h2 class="text-xl font-bold tracking-tight mb-4">3. Paste and restart</h2>
+      <div class="space-y-4">
+        <div class="flex items-start gap-4">
+          <span class="flex items-center justify-center w-8 h-8 rounded-full bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-sm font-bold text-[var(--color-accent)] shrink-0">1</span>
+          <div>
+            <p class="font-medium">Paste the config</p>
+            <p class="text-sm text-[var(--color-text-muted)]">If you already have other MCP servers configured, merge the <code class="font-mono text-xs bg-[var(--color-bg)] px-1.5 py-0.5 rounded">lattice</code> entry into your existing <code class="font-mono text-xs bg-[var(--color-bg)] px-1.5 py-0.5 rounded">mcpServers</code> object.</p>
+          </div>
+        </div>
+        <div class="flex items-start gap-4">
+          <span class="flex items-center justify-center w-8 h-8 rounded-full bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-sm font-bold text-[var(--color-accent)] shrink-0">2</span>
+          <div>
+            <p class="font-medium">Restart Claude Desktop</p>
+            <p class="text-sm text-[var(--color-text-muted)]">Quit and reopen Claude Desktop so it picks up the new config.</p>
+          </div>
+        </div>
+        <div class="flex items-start gap-4">
+          <span class="flex items-center justify-center w-8 h-8 rounded-full bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-sm font-bold text-[var(--color-accent)] shrink-0">3</span>
+          <div>
+            <p class="font-medium">Ask your first question</p>
+            <p class="text-sm text-[var(--color-text-muted)]">Try: <em>"What topics are available on Lattice?"</em></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Troubleshooting -->
+    <section class="mb-16" data-reveal>
+      <h2 class="text-xl font-bold tracking-tight mb-4">Troubleshooting</h2>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl divide-y divide-[var(--color-border)]">
+        <div class="p-5">
+          <p class="font-medium text-sm mb-1">"Server not found"</p>
+          <p class="text-sm text-[var(--color-text-muted)]">Make sure Node.js 18+ is installed and <code class="font-mono text-xs bg-[var(--color-bg)] px-1.5 py-0.5 rounded">npx</code> is available in your PATH.</p>
+        </div>
+        <div class="p-5">
+          <p class="font-medium text-sm mb-1">"Connection failed"</p>
+          <p class="text-sm text-[var(--color-text-muted)]">Verify the JSON config is valid — a missing comma or bracket will break parsing.</p>
+        </div>
+        <div class="p-5">
+          <p class="font-medium text-sm mb-1">Still stuck?</p>
+          <p class="text-sm text-[var(--color-text-muted)]">
+            <a href="https://github.com/ferrislabs/ferrisletter/issues" target="_blank" rel="noopener" class="text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors">Open an issue on GitHub</a> and we'll help you out.
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
+  <Footer />
+</Layout>
+
+<script>
+  document.querySelectorAll('[data-reveal]').forEach((el) => {
+    el.classList.add('opacity-0', 'translate-y-6');
+    (el as HTMLElement).style.transition = 'opacity 0.7s ease-out, transform 0.7s ease-out';
+    new IntersectionObserver(([e]) => {
+      if (e.isIntersecting) {
+        el.classList.remove('opacity-0', 'translate-y-6');
+      }
+    }, { threshold: 0.15 }).observe(el);
+  });
+</script>

--- a/website/src/pages/docs/building-connectors.astro
+++ b/website/src/pages/docs/building-connectors.astro
@@ -1,0 +1,43 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import CodeBlock from '../../components/CodeBlock';
+
+const connectorTrait = `#[async_trait]
+pub trait Connector: Send + Sync {
+    /// Fetch items from this content source.
+    async fn fetch_items(&self) -> Result<Vec<Item>>;
+
+    /// A human-readable name for this source.
+    fn source_name(&self) -> &str;
+}`;
+---
+
+<DocsLayout title="Building Connectors" description="Build your own content source with the Ferrisletter Connector SDK.">
+  <h1>Building Connectors</h1>
+  <p>Ferrisletter's connector system is pluggable — anyone can build a connector to bring in content from any source. RSS feeds, APIs, databases, scrapers — if you can fetch it, you can serve it.</p>
+
+  <h2>The Connector trait</h2>
+  <p>At its core, a connector implements a single trait:</p>
+  <CodeBlock code={connectorTrait} filename="connector.rs" client:load />
+  <p>The <code>Item</code> struct contains fields for headline, summary, source URL, publication date, topic, and tags.</p>
+
+  <h2>Built-in connectors</h2>
+  <ul>
+    <li><strong>connector-rss</strong> — Fetches items from RSS and Atom feeds</li>
+    <li><strong>connector-static</strong> — Serves items from a static JSON file (useful for testing)</li>
+  </ul>
+
+  <h2>Getting started</h2>
+  <ol>
+    <li>Add <code>ferrisletter-connector</code> as a dependency from <a href="https://crates.io/crates/ferrisletter-connector" target="_blank" rel="noopener">crates.io</a></li>
+    <li>Implement the <code>Connector</code> trait for your source</li>
+    <li>Register your connector in the server configuration</li>
+    <li>Items from your connector will appear alongside other content in the user's feed</li>
+  </ol>
+
+  <h2>Resources</h2>
+  <ul>
+    <li><a href="https://crates.io/crates/ferrisletter-connector" target="_blank" rel="noopener">ferrisletter-connector on crates.io</a></li>
+    <li><a href="https://github.com/ferrislabs/ferrisletter" target="_blank" rel="noopener">GitHub repository</a> — see <code>crates/connector-rss</code> for a reference implementation</li>
+  </ul>
+</DocsLayout>

--- a/website/src/pages/docs/connect-claude.astro
+++ b/website/src/pages/docs/connect-claude.astro
@@ -1,0 +1,50 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import CodeBlock from '../../components/CodeBlock';
+
+const configJson = `{
+  "mcpServers": {
+    "lattice": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://mcp.ferrisletter.dev/mcp"]
+    }
+  }
+}`;
+---
+
+<DocsLayout title="Connect to Claude" description="Step-by-step instructions for connecting Ferrisletter to Claude Desktop.">
+  <h1>Connect to Claude</h1>
+  <p>This guide walks you through connecting Lattice to Claude Desktop using <code>mcp-remote</code>.</p>
+
+  <h2>Prerequisites</h2>
+  <ul>
+    <li><strong>Node.js 18+</strong> — needed for <code>npx</code> to run mcp-remote</li>
+    <li><strong>Claude Desktop</strong> — requires a Pro, Max, Team, or Enterprise plan</li>
+  </ul>
+
+  <h2>Configuration</h2>
+  <p>Add the following to your Claude Desktop config file:</p>
+  <CodeBlock code={configJson} filename="claude_desktop_config.json" client:load />
+
+  <h2>Config file location</h2>
+  <ul>
+    <li><strong>macOS:</strong> <code>~/Library/Application Support/Claude/claude_desktop_config.json</code></li>
+    <li><strong>Windows:</strong> <code>%APPDATA%\Claude\claude_desktop_config.json</code></li>
+  </ul>
+  <p>If the file doesn't exist, create it. If you already have other MCP servers configured, merge the <code>lattice</code> entry into your existing <code>mcpServers</code> object.</p>
+
+  <h2>Why mcp-remote?</h2>
+  <p>Claude Desktop currently supports stdio-based MCP servers. The <code>mcp-remote</code> package bridges the gap — it connects to the remote Lattice server over SSE/HTTP and presents it to Claude Desktop as a local stdio server. No local installation of Ferrisletter is required.</p>
+
+  <h2>Alternative: Settings &rarr; Integrations</h2>
+  <p>If Claude Desktop supports remote MCP servers natively (via Settings &rarr; Integrations), you can add the URL directly:</p>
+  <CodeBlock code="https://mcp.ferrisletter.dev/mcp" client:load />
+  <p>This method doesn't require Node.js.</p>
+
+  <h2>Verify the connection</h2>
+  <p>After restarting Claude Desktop, ask:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "What topics are available on Lattice?"
+  </blockquote>
+  <p>If you see a list of topics, the connection is working.</p>
+</DocsLayout>

--- a/website/src/pages/docs/display-preferences.astro
+++ b/website/src/pages/docs/display-preferences.astro
@@ -1,0 +1,52 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Display Preferences" description="Customize your digest appearance with themes and natural language instructions.">
+  <h1>Display Preferences</h1>
+  <p>Customize how your digest looks — from pre-built themes to fully custom styling described in natural language.</p>
+
+  <h2>Themes</h2>
+  <p>Lattice ships with 5 built-in theme presets:</p>
+  <ul>
+    <li><strong>Default</strong> — Clean dark theme with purple accents</li>
+    <li><strong>Light</strong> — Bright white background for daytime reading</li>
+    <li><strong>Daltonian</strong> — Colorblind-safe palette using blue and orange (no red-green)</li>
+    <li><strong>High Contrast</strong> — WCAG AAA compliant with maximum readability</li>
+    <li><strong>Minimal</strong> — Headlines only, monospace font, tight spacing</li>
+  </ul>
+  <p>Preview all themes on the <a href="/themes">Themes page</a>.</p>
+  <p>To switch themes, just tell Claude:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Switch to the light theme"
+  </blockquote>
+
+  <h2>Custom instructions</h2>
+  <p>Go beyond presets with natural language display instructions. Examples:</p>
+  <ul>
+    <li>"Use emoji headers for each section"</li>
+    <li>"Group items by tag instead of topic"</li>
+    <li>"Larger fonts with more spacing"</li>
+    <li>"Only show headlines, no summaries"</li>
+    <li>"Use a colorblind-safe palette with sans-serif fonts"</li>
+  </ul>
+  <p>These instructions are stored in your preferences and applied every time Claude generates a digest.</p>
+
+  <h2>Summary length</h2>
+  <p>Control how much detail appears in each item:</p>
+  <ul>
+    <li><strong>Brief</strong> — Headlines and source only</li>
+    <li><strong>Standard</strong> — Headlines with a one-line summary (default)</li>
+    <li><strong>Detailed</strong> — Full summaries with additional context</li>
+  </ul>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Set my summary length to brief"
+  </blockquote>
+
+  <h2>Updating preferences</h2>
+  <p>Just tell Claude what you want to change — no settings page needed:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Update my display preferences to use the daltonian theme with emoji headers"
+  </blockquote>
+  <p>Claude will confirm the changes and apply them to your next digest.</p>
+</DocsLayout>

--- a/website/src/pages/docs/getting-started.astro
+++ b/website/src/pages/docs/getting-started.astro
@@ -1,0 +1,48 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import CodeBlock from '../../components/CodeBlock';
+
+const configJson = `{
+  "mcpServers": {
+    "lattice": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://mcp.ferrisletter.dev/mcp"]
+    }
+  }
+}`;
+---
+
+<DocsLayout title="Getting Started" description="Get up and running with Ferrisletter in under 2 minutes.">
+  <h1>Getting Started</h1>
+  <p>Get up and running with Lattice in under 2 minutes. All you need is Node.js and Claude Desktop.</p>
+
+  <h2>1. Add Lattice to Claude Desktop</h2>
+  <p>Copy this config into your Claude Desktop configuration file:</p>
+  <CodeBlock code={configJson} filename="claude_desktop_config.json" client:load />
+  <p class="mt-4">See <a href="/docs/connect-claude">Connect to Claude</a> for detailed instructions on where to find the config file.</p>
+
+  <h2>2. Restart Claude Desktop</h2>
+  <p>Quit and reopen Claude Desktop so it picks up the new MCP server configuration.</p>
+
+  <h2>3. Discover topics</h2>
+  <p>Ask Claude:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "What topics are available on Lattice?"
+  </blockquote>
+
+  <h2>4. Subscribe to topics</h2>
+  <p>Tell Claude which topics interest you:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Subscribe me to Rust and AI topics"
+  </blockquote>
+
+  <h2>5. Set up scheduled delivery</h2>
+  <p>Configure automatic digest delivery:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Set up daily delivery at 9am on weekdays"
+  </blockquote>
+  <p>See <a href="/docs/scheduled-delivery">Scheduled Delivery</a> for more options.</p>
+
+  <h2>6. Done!</h2>
+  <p>Your personalized newsletter is set up. Claude will deliver your digest on schedule, or you can ask for it anytime with "Show me my feed" or "What did I miss this week?"</p>
+</DocsLayout>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -1,0 +1,28 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+
+const pages = [
+  { title: 'Getting Started', href: '/docs/getting-started', description: 'Set up Lattice in Claude Desktop in under 2 minutes.' },
+  { title: 'Connect to Claude', href: '/docs/connect-claude', description: 'Detailed config instructions for Claude Desktop with mcp-remote.' },
+  { title: 'Display Preferences', href: '/docs/display-preferences', description: 'Customize your digest theme, layout, and style.' },
+  { title: 'Scheduled Delivery', href: '/docs/scheduled-delivery', description: 'Set up automatic daily or weekly digest delivery.' },
+  { title: 'Building Connectors', href: '/docs/building-connectors', description: 'Build your own content source with the Connector SDK.' },
+];
+---
+
+<DocsLayout title="Documentation" description="Learn how to set up, configure, and extend Ferrisletter.">
+  <h1>Documentation</h1>
+  <p class="text-lg mb-8">Everything you need to get started with Ferrisletter and Lattice.</p>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    {pages.map((page) => (
+      <a
+        href={page.href}
+        class="block p-5 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl hover:border-[var(--color-border-hover)] transition-all group"
+      >
+        <h3 class="font-semibold text-[var(--color-text)] group-hover:text-[var(--color-accent)] transition-colors mb-1">{page.title}</h3>
+        <p class="text-sm text-[var(--color-text-muted)]">{page.description}</p>
+      </a>
+    ))}
+  </div>
+</DocsLayout>

--- a/website/src/pages/docs/scheduled-delivery.astro
+++ b/website/src/pages/docs/scheduled-delivery.astro
@@ -1,0 +1,43 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro';
+---
+
+<DocsLayout title="Scheduled Delivery" description="Set up automatic daily or weekly digest delivery.">
+  <h1>Scheduled Delivery</h1>
+  <p>Lattice can deliver your personalized digest on a schedule — daily, on weekdays, or weekly. Claude handles everything automatically.</p>
+
+  <h2>Setting up delivery</h2>
+  <p>Tell Claude when you'd like to receive your digest:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Set up daily delivery at 9am on weekdays"
+  </blockquote>
+
+  <h3>Frequency options</h3>
+  <ul>
+    <li><strong>Daily</strong> — Every day at your chosen time</li>
+    <li><strong>Weekdays</strong> — Monday through Friday</li>
+    <li><strong>Weekly</strong> — Once a week on a specific day</li>
+  </ul>
+
+  <h2>How it works</h2>
+  <p>When your scheduled delivery fires, Claude automatically:</p>
+  <ol>
+    <li>Loads your preferences (subscribed topics, display settings, theme)</li>
+    <li>Fetches your unread feed</li>
+    <li>Generates a styled HTML digest artifact based on your preferences</li>
+    <li>Marks all delivered items as read</li>
+  </ol>
+  <p>The digest appears as an artifact in a new Claude conversation — you just open Claude and it's waiting for you.</p>
+
+  <h2>Changing frequency</h2>
+  <p>Update your schedule anytime:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Change my delivery to weekly on Mondays at 8am"
+  </blockquote>
+
+  <h2>On-demand delivery</h2>
+  <p>You can also request a digest at any time without waiting for the schedule:</p>
+  <blockquote class="border-l-2 border-[var(--color-accent)] pl-4 text-[var(--color-text-muted)] italic my-4">
+    "Show me my feed" or "What did I miss this week?"
+  </blockquote>
+</DocsLayout>

--- a/website/src/pages/features.astro
+++ b/website/src/pages/features.astro
@@ -1,0 +1,219 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Nav from '../components/Nav';
+import PageHeader from '../components/PageHeader.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Layout title="Features — Ferrisletter" description="Explore what makes Ferrisletter different: Generative UI digests, MCP App panels, smart delivery, and more.">
+  <Nav client:load />
+  <div class="max-w-[1200px] mx-auto px-8">
+    <PageHeader
+      tag="Features"
+      title="Everything you need in a conversational newsletter"
+      subtitle="From personalized digests to open-source extensibility — built for the way you actually consume information."
+    />
+
+    <!-- Personalized Digest -->
+    <section class="py-16 grid grid-cols-1 md:grid-cols-2 gap-12 items-center" data-reveal>
+      <div>
+        <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">Generative UI</span>
+        <h2 class="text-2xl font-extrabold tracking-tight mb-4">Your daily tech digest, styled your way</h2>
+        <p class="text-[var(--color-text-muted)] leading-relaxed mb-4">
+          Every morning, Claude generates a styled interactive HTML digest tailored to your subscriptions. It's not a template — it's freshly generated each time based on your preferences and the latest content.
+        </p>
+        <ul class="space-y-2 text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Customize with natural language: "use colorblind-safe colors", "add emoji headers"</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>5 built-in theme presets — or describe your own</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Rendered as a rich artifact right in Claude</li>
+        </ul>
+        <a href="/themes" class="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] mt-4 transition-colors">
+          Browse themes &rarr;
+        </a>
+      </div>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl p-6 relative overflow-hidden">
+        <div class="absolute inset-0 bg-gradient-to-br from-[rgba(109,90,255,0.05)] via-transparent to-[rgba(34,211,238,0.03)] pointer-events-none"></div>
+        <div class="relative space-y-3">
+          <div class="flex items-center justify-between text-xs text-[var(--color-text-dim)]">
+            <span class="font-mono font-semibold text-[var(--color-accent)]">Lattice Digest</span>
+            <span>April 12, 2026</span>
+          </div>
+          <div class="border-t border-[var(--color-border)] pt-3">
+            <span class="inline-block text-[0.65rem] font-semibold uppercase tracking-wider text-[var(--color-accent)] bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] px-2 py-0.5 rounded-full mb-2">Rust</span>
+            <p class="font-semibold text-sm mb-1">Async closures hit stable in Rust 1.94</p>
+            <p class="text-xs text-[var(--color-text-muted)]">Eliminating a major pain point for async code.</p>
+          </div>
+          <div class="border-t border-[var(--color-border)] pt-3">
+            <span class="inline-block text-[0.65rem] font-semibold uppercase tracking-wider text-[var(--color-accent-secondary)] bg-[rgba(34,211,238,0.1)] border border-[rgba(34,211,238,0.25)] px-2 py-0.5 rounded-full mb-2">AI</span>
+            <p class="font-semibold text-sm mb-1">Claude 4.5 Opus released with 1M context</p>
+            <p class="text-xs text-[var(--color-text-muted)]">The most capable model yet, now generally available.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Interactive Dashboard -->
+    <section class="py-16 grid grid-cols-1 md:grid-cols-2 gap-12 items-center" data-reveal>
+      <div class="md:order-2">
+        <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">MCP App</span>
+        <h2 class="text-2xl font-extrabold tracking-tight mb-4">Browse, search, and explore — right inside Claude</h2>
+        <p class="text-[var(--color-text-muted)] leading-relaxed mb-4">
+          The MCP App UI renders an interactive dashboard directly alongside your conversation. Filter by topic, expand articles, track what you've read — all without leaving Claude Desktop.
+        </p>
+        <ul class="space-y-2 text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Topic filtering and full-text search</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Expand items inline to read full content</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Read/unread tracking across sessions</li>
+        </ul>
+      </div>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl p-6 md:order-1">
+        <div class="space-y-3">
+          <div class="flex items-center gap-2 mb-3">
+            <div class="w-2 h-2 rounded-full bg-[var(--color-accent)]"></div>
+            <span class="text-xs font-mono text-[var(--color-text-dim)]">ferrisletter panel</span>
+          </div>
+          <div class="flex gap-2 mb-3">
+            <span class="px-2.5 py-1 text-[0.65rem] font-medium rounded-full bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-[var(--color-accent)]">All</span>
+            <span class="px-2.5 py-1 text-[0.65rem] font-medium rounded-full bg-transparent border border-[var(--color-border)] text-[var(--color-text-dim)]">Rust</span>
+            <span class="px-2.5 py-1 text-[0.65rem] font-medium rounded-full bg-transparent border border-[var(--color-border)] text-[var(--color-text-dim)]">AI</span>
+            <span class="px-2.5 py-1 text-[0.65rem] font-medium rounded-full bg-transparent border border-[var(--color-border)] text-[var(--color-text-dim)]">MCP</span>
+          </div>
+          <div class="space-y-2">
+            <div class="p-3 rounded-lg bg-[var(--color-bg-card)] border border-[var(--color-border)]">
+              <p class="text-sm font-medium">New MCP transport spec draft</p>
+              <p class="text-xs text-[var(--color-text-dim)] mt-1">modelcontextprotocol.io &middot; 3 min</p>
+            </div>
+            <div class="p-3 rounded-lg bg-[var(--color-bg-card)] border border-[var(--color-border)]">
+              <p class="text-sm font-medium">Tokio 2.0 roadmap published</p>
+              <p class="text-xs text-[var(--color-text-dim)] mt-1">tokio.rs &middot; 5 min</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Smart Delivery -->
+    <section class="py-16 grid grid-cols-1 md:grid-cols-2 gap-12 items-center" data-reveal>
+      <div>
+        <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">Scheduler</span>
+        <h2 class="text-2xl font-extrabold tracking-tight mb-4">Set it and forget it</h2>
+        <p class="text-[var(--color-text-muted)] leading-relaxed mb-4">
+          Configure delivery with a single sentence. Claude calls the tools on your schedule — loading your preferences, fetching your feed, generating the digest, and marking items as read. You just open Claude and it's there.
+        </p>
+        <ul class="space-y-2 text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Daily, weekday, or weekly frequency</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Pick your preferred delivery time</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Fully automated — no manual triggers needed</li>
+        </ul>
+      </div>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl p-6">
+        <div class="space-y-4 font-mono text-sm">
+          <div class="flex items-start gap-3">
+            <span class="text-[var(--color-accent)] shrink-0 mt-0.5">&#9656;</span>
+            <span class="text-[var(--color-text-muted)]">"Set up daily delivery at 9am on weekdays"</span>
+          </div>
+          <div class="flex items-start gap-3">
+            <span class="text-[var(--color-accent-secondary)] shrink-0 mt-0.5">&#9671;</span>
+            <span class="text-[var(--color-text-dim)]">Scheduled: weekdays at 9:00 AM. I'll load your preferences, fetch your unread feed, generate a styled digest, and mark everything as read.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Natural Language Personalization -->
+    <section class="py-16 grid grid-cols-1 md:grid-cols-2 gap-12 items-center" data-reveal>
+      <div class="md:order-2">
+        <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">Personalization</span>
+        <h2 class="text-2xl font-extrabold tracking-tight mb-4">Your newsletter, your rules</h2>
+        <p class="text-[var(--color-text-muted)] leading-relaxed mb-4">
+          No settings page, no checkboxes. Just tell Claude what you want. Subscribe to topics, adjust your display, change your theme — all through natural conversation.
+        </p>
+        <ul class="space-y-2 text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Pick topics and tags conversationally</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Custom display instructions (emoji headers, grouping, font size)</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Read tracking — never see the same item twice</li>
+        </ul>
+      </div>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl p-6 md:order-1">
+        <div class="space-y-4 font-mono text-sm">
+          <div class="flex items-start gap-3">
+            <span class="text-[var(--color-accent)] shrink-0 mt-0.5">&#9656;</span>
+            <span class="text-[var(--color-text-muted)]">"Subscribe me to Rust and AI topics"</span>
+          </div>
+          <div class="flex items-start gap-3">
+            <span class="text-[var(--color-accent-secondary)] shrink-0 mt-0.5">&#9671;</span>
+            <span class="text-[var(--color-text-dim)]">Done! You're now subscribed to Rust and AI. You have 12 unread items.</span>
+          </div>
+          <div class="border-t border-[var(--color-border)] pt-4 flex items-start gap-3">
+            <span class="text-[var(--color-accent)] shrink-0 mt-0.5">&#9656;</span>
+            <span class="text-[var(--color-text-muted)]">"Use a colorblind-safe theme with emoji headers"</span>
+          </div>
+          <div class="flex items-start gap-3">
+            <span class="text-[var(--color-accent-secondary)] shrink-0 mt-0.5">&#9671;</span>
+            <span class="text-[var(--color-text-dim)]">Updated! Your next digest will use the Daltonian theme with emoji section headers.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Open Platform -->
+    <section class="py-16 grid grid-cols-1 md:grid-cols-2 gap-12 items-center" data-reveal>
+      <div>
+        <span class="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">Open Source</span>
+        <h2 class="text-2xl font-extrabold tracking-tight mb-4">Built on an open platform</h2>
+        <p class="text-[var(--color-text-muted)] leading-relaxed mb-4">
+          Ferrisletter is an open-source MCP newsletter SDK. The connector system is pluggable — anyone can build a connector to bring in content from any source. Published on crates.io, MIT licensed.
+        </p>
+        <ul class="space-y-2 text-[var(--color-text-muted)]">
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Pluggable connector system (RSS, static, custom)</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>Built with Rust for performance and reliability</li>
+          <li class="flex items-start gap-2"><span class="text-[var(--color-accent)] mt-1">&#9671;</span>MCP-native — works with any MCP client</li>
+        </ul>
+        <div class="flex gap-3 mt-4">
+          <a
+            href="https://github.com/ferrislabs/ferrisletter"
+            target="_blank"
+            rel="noopener"
+            class="inline-flex items-center gap-2 px-5 py-2 bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-lg text-sm font-medium hover:border-[var(--color-border-hover)] transition-all"
+          >
+            GitHub &rarr;
+          </a>
+          <a
+            href="/docs/building-connectors"
+            class="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors py-2"
+          >
+            Build a connector &rarr;
+          </a>
+        </div>
+      </div>
+      <div class="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl p-6">
+        <div class="space-y-3 font-mono text-xs text-[var(--color-text-dim)]">
+          <div class="flex items-center gap-2 text-[var(--color-text-muted)] text-sm font-semibold mb-3">
+            <span class="text-[var(--color-accent)]">&#9671;</span>
+            ferrisletter-connector
+          </div>
+          <div class="bg-[var(--color-bg)] rounded-lg p-4 overflow-x-auto">
+            <pre class="text-[var(--color-text-muted)]" set:html={`<span class="text-[var(--color-accent)]">pub trait</span> Connector: Send + Sync {
+    <span class="text-[var(--color-accent)]">async fn</span> fetch_items(&amp;self)
+        -&gt; Result&lt;Vec&lt;Item&gt;&gt;;
+    <span class="text-[var(--color-accent)]">fn</span> source_name(&amp;self) -&gt; &amp;str;
+}`} />
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+  <Footer />
+</Layout>
+
+<script>
+  document.querySelectorAll('[data-reveal]').forEach((el) => {
+    el.classList.add('opacity-0', 'translate-y-6');
+    (el as HTMLElement).style.transition = 'opacity 0.7s ease-out, transform 0.7s ease-out';
+    new IntersectionObserver(([e]) => {
+      if (e.isIntersecting) {
+        el.classList.remove('opacity-0', 'translate-y-6');
+      }
+    }, { threshold: 0.15 }).observe(el);
+  });
+</script>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,6 +8,7 @@ import Features from '../components/Features';
 import Architecture from '../components/Architecture';
 import TechStack from '../components/TechStack';
 import CTA from '../components/CTA';
+import Footer from '../components/Footer.astro';
 ---
 
 <Layout>
@@ -19,4 +20,5 @@ import CTA from '../components/CTA';
   <Architecture client:visible />
   <TechStack client:visible />
   <CTA client:visible />
+  <Footer />
 </Layout>

--- a/website/src/pages/themes.astro
+++ b/website/src/pages/themes.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Nav from '../components/Nav';
+import PageHeader from '../components/PageHeader.astro';
+import ThemeGallery from '../components/ThemeGallery';
+import Footer from '../components/Footer.astro';
+---
+
+<Layout title="Themes — Ferrisletter" description="Preview the 5 built-in digest themes: Default, Light, Daltonian, High Contrast, and Minimal.">
+  <Nav client:load />
+  <div class="max-w-[1200px] mx-auto px-8">
+    <PageHeader
+      tag="Themes"
+      title="See your digest in every style"
+      subtitle="Five built-in presets for your Generative UI digest. Switch anytime — or describe your own custom look."
+    />
+    <ThemeGallery client:visible />
+  </div>
+  <div class="py-16"></div>
+  <Footer />
+</Layout>


### PR DESCRIPTION
## Summary
- **#91** — Updated Nav with page links (Features, Themes, Docs, Connect), mobile hamburger menu, extracted Footer into standalone component, updated CTA buttons
- **#88** — New `/features` page with 5 sections: Generative UI digest, MCP App dashboard, smart delivery, personalization, open platform
- **#87** — New `/themes` page with interactive gallery showcasing 5 digest theme presets (Default, Light, Daltonian, High Contrast, Minimal)
- **#90** — New `/connect` page with copy-paste mcp-remote config, setup steps, prerequisites, and troubleshooting
- **#89** — New `/docs` section with 6 pages: overview, getting started, connect to Claude, display preferences, scheduled delivery, building connectors

## New files (17)
- 4 reusable components: `Footer.astro`, `PageHeader.astro`, `CodeBlock.tsx`, `DocsSidebar.tsx`, `ThemeGallery.tsx`
- 1 layout: `DocsLayout.astro`
- 10 pages: `/features`, `/themes`, `/connect`, `/docs` (6 pages)

## Test plan
- [x] `cd website && npm run build` succeeds — 10 pages generated with no errors
- [x] All Rust tests pass (pre-push hook)
- [ ] Visual review of each page in browser
- [ ] Mobile responsiveness check (hamburger nav, docs sidebar collapse)
- [ ] CodeBlock copy button works
- [ ] Theme gallery tab switching works

Closes #91, #88, #87, #90, #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)