### PR TITLE
feat(website): MCP App UI showcase + landing page theme previews

### DIFF
--- a/website/src/components/HowItsDifferent.tsx
+++ b/website/src/components/HowItsDifferent.tsx
@@ -6,112 +6,322 @@ export default function HowItsDifferent() {
 
   useEffect(() => {
     if (!ref.current) return;
-    const observer = new IntersectionObserver(([entry]) => { if (entry.isIntersecting) setVisible(true); }, { threshold: 0.3 });
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) setVisible(true); },
+      { threshold: 0.1 },
+    );
     observer.observe(ref.current);
     return () => observer.disconnect();
   }, []);
 
   return (
-    <section className="py-28 relative z-[1]" ref={ref}>
+    <section id="how-it-works" className="py-28 relative z-[1]" ref={ref}>
       <div className="max-w-[1200px] mx-auto px-8">
-        <div
-          className={`grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-8 items-center transition-all duration-700 ease-out ${
-            visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
-          }`}
-        >
-          {/* Traditional */}
-          <div>
-            <div className="font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-6 text-center">
-              Traditional Newsletter
-            </div>
-            <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-xl overflow-hidden min-h-[360px]">
-              <div className="p-5">
-                <div className="mb-5 pb-4 border-b border-[var(--color-border)]">
-                  <div className="flex items-center gap-2 text-xs text-[var(--color-text-dim)] mb-1">
-                    <span className="w-2 h-2 rounded-full bg-[var(--color-border-hover)]" />
-                    newsletter@weekly-digest.com
-                  </div>
-                  <div className="text-sm font-semibold text-[var(--color-text-muted)]">Your Weekly AI Digest #147</div>
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <div className="h-2.5 bg-[var(--color-border)] rounded opacity-70 w-3/5" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50 w-2/5" />
-                  <div className="h-3" />
-                  <div className="h-2.5 bg-[var(--color-border)] rounded opacity-70 w-3/5" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50 w-2/5" />
-                  <div className="h-3" />
-                  <div className="h-2.5 bg-[var(--color-border)] rounded opacity-70 w-3/5" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-50 w-2/5" />
-                  <div className="h-3" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-20" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-20" />
-                  <div className="h-2 bg-[var(--color-border)] rounded opacity-20 w-2/5" />
-                </div>
-                <div className="text-center text-xs text-[var(--color-text-dim)] pt-4 opacity-50">&#8942; 2000+ more words</div>
-              </div>
-            </div>
-            <p className="text-center text-sm text-[var(--color-text-dim)] mt-4 font-medium">Long. Static. All or nothing.</p>
-          </div>
-
-          {/* Divider */}
-          <div className="flex md:flex-col items-center justify-center">
-            <span className="font-mono text-xs text-[var(--color-text-dim)] bg-[var(--color-bg)] px-2 py-1 rounded-md border border-[var(--color-border)]">
-              vs
+        {/* Header */}
+        <div className="text-center mb-20">
+          <span className="inline-block font-mono text-xs font-medium text-[var(--color-accent)] uppercase tracking-widest mb-4">
+            How it works
+          </span>
+          <h2 className="text-[clamp(2rem,5vw,3.2rem)] font-extrabold tracking-tight leading-tight mb-4">
+            Four steps to your{' '}
+            <span className="bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-secondary)] bg-clip-text text-transparent">
+              personal newsroom
             </span>
-          </div>
+          </h2>
+          <p className="text-lg text-[var(--color-text-muted)] max-w-[520px] mx-auto">
+            An interactive UI that renders right inside Claude — no separate app needed.
+          </p>
+        </div>
 
-          {/* AI Letter */}
-          <div>
-            <div className="font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-6 text-center">
-              Ferrisletter
-            </div>
-            <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-tag-border)] rounded-xl overflow-hidden min-h-[360px] shadow-[0_0_40px_var(--color-accent-glow)]">
-              <div className="p-5 flex flex-col gap-3">
-                <div className="flex items-center justify-center gap-1.5 px-3 py-1 font-mono text-[0.6rem] font-medium text-[var(--color-accent)] bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] rounded-full w-fit mx-auto">
-                  <span className="text-[0.7rem]">&#9889;</span>
-                  Scheduled: weekly digest
+        <div className="flex flex-col gap-24">
+          {/* Step 1: Connect */}
+          <Step
+            index={0}
+            visible={visible}
+            tag="Step 1"
+            title="Connect in seconds"
+            description="Add a single config snippet to Claude Desktop. The MCP server connects automatically — no install, no build, no signup."
+            highlight="Paste the config, restart Claude, and you're live."
+            link={{ href: '/connect', label: 'Setup guide' }}
+          >
+            <MockClaudeWindow title="claude_desktop_config.json">
+              <pre className="font-mono text-xs text-[var(--color-text-muted)] leading-relaxed p-4">
+                <span className="text-[var(--color-text-dim)]">{'{'}</span>{'\n'}
+                {'  '}<span className="text-[var(--color-accent)]">"mcpServers"</span>: {'{'}{'\n'}
+                {'    '}<span className="text-[var(--color-accent)]">"lattice"</span>: {'{'}{'\n'}
+                {'      '}<span className="text-[var(--color-text-dim)]">"command"</span>: <span className="text-[var(--color-accent-secondary)]">"npx"</span>,{'\n'}
+                {'      '}<span className="text-[var(--color-text-dim)]">"args"</span>: [<span className="text-[var(--color-accent-secondary)]">"mcp-remote@latest"</span>, <span className="text-[var(--color-accent-secondary)]">"https://..."</span>]{'\n'}
+                {'    }'}{'\n'}
+                {'  }'}{'\n'}
+                <span className="text-[var(--color-text-dim)]">{'}'}</span>
+              </pre>
+              <div className="px-4 pb-3 flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                <span className="text-[0.65rem] text-green-400 font-mono">lattice connected</span>
+              </div>
+            </MockClaudeWindow>
+          </Step>
+
+          {/* Step 2: Browse */}
+          <Step
+            index={1}
+            visible={visible}
+            tag="Step 2"
+            title="Browse your feed"
+            description="The MCP App UI renders an interactive panel directly inside Claude. Filter by topic, scan headlines, and expand any item to read the full content."
+            highlight="This UI renders right inside Claude — no separate app needed."
+          >
+            <MockClaudeWindow title="ferrisletter panel">
+              <div className="p-4 space-y-3">
+                {/* Topic filters */}
+                <div className="flex gap-2 flex-wrap">
+                  {['All', 'Rust', 'AI', 'MCP'].map((t, i) => (
+                    <span
+                      key={t}
+                      className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full ${
+                        i === 0
+                          ? 'bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-[var(--color-accent)]'
+                          : 'bg-transparent border border-[var(--color-border)] text-[var(--color-text-dim)]'
+                      }`}
+                    >
+                      {t}
+                    </span>
+                  ))}
                 </div>
-                <div className="bg-[var(--color-bg-card)] border border-[var(--color-border)] rounded-lg p-3">
-                  <div className="flex flex-col">
+                {/* Items */}
+                <div className="space-y-2">
+                  <ItemRow
+                    topic="Rust"
+                    headline="Async closures hit stable in Rust 1.94"
+                    meta="blog.rust-lang.org · 4 min"
+                    expanded
+                    summary="The long-awaited async closures feature lands in stable Rust, eliminating a major friction point for async code."
+                  />
+                  <ItemRow
+                    topic="AI"
+                    headline="MCP Apps spec reaches v1.0"
+                    meta="modelcontextprotocol.io · 3 min"
+                  />
+                  <ItemRow
+                    topic="MCP"
+                    headline="New transport layer draft published"
+                    meta="github.com · 2 min"
+                  />
+                </div>
+              </div>
+            </MockClaudeWindow>
+          </Step>
+
+          {/* Step 3: Interact */}
+          <Step
+            index={2}
+            visible={visible}
+            tag="Step 3"
+            title="Search and explore"
+            description="Ask Claude for a recap of what you missed, search by keyword, or filter by tags. The UI updates in real-time alongside the conversation."
+            highlight="Search, filter, and explore — all within the conversation."
+          >
+            <MockClaudeWindow title="ferrisletter search">
+              <div className="p-4 space-y-3">
+                {/* Search bar mockup */}
+                <div className="flex items-center gap-2 px-3 py-2 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg">
+                  <span className="text-[var(--color-text-dim)] text-xs">&#128269;</span>
+                  <span className="font-mono text-xs text-[var(--color-text-muted)]">async closures</span>
+                </div>
+                {/* Results */}
+                <div className="text-[0.65rem] text-[var(--color-text-dim)] font-mono mb-1">3 results</div>
+                <div className="space-y-2">
+                  <ItemRow
+                    topic="Rust"
+                    headline="Async closures hit stable in Rust 1.94"
+                    meta="blog.rust-lang.org · Apr 5"
+                  />
+                  <ItemRow
+                    topic="Rust"
+                    headline="RFC: async closure trait bounds"
+                    meta="github.com/rust-lang · Mar 28"
+                  />
+                  <ItemRow
+                    topic="Rust"
+                    headline="Async patterns in embedded Rust"
+                    meta="embedded.rs · Mar 15"
+                  />
+                </div>
+              </div>
+            </MockClaudeWindow>
+          </Step>
+
+          {/* Step 4: Personalize */}
+          <Step
+            index={3}
+            visible={visible}
+            tag="Step 4"
+            title="Make it yours"
+            description="Subscribe to topics, set your preferred theme, configure delivery — all through natural conversation. No settings page needed."
+            highlight="Tell Claude what you care about. The UI updates instantly."
+            link={{ href: '/features', label: 'See all features' }}
+          >
+            <MockClaudeWindow title="preferences">
+              <div className="p-4 space-y-4">
+                {/* Topic picker */}
+                <div>
+                  <div className="text-[0.65rem] font-semibold uppercase tracking-wider text-[var(--color-text-dim)] mb-2">Subscribed topics</div>
+                  <div className="flex gap-2 flex-wrap">
                     {[
-                      { tag: 'Research', text: 'New arch beats SOTA with fewer params', active: false },
-                      { tag: 'OSS', text: 'LLM framework goes v3.0', active: false },
-                      { tag: 'Industry', text: 'AI chip merger shakes up market', active: true, expanded: 'Two startups combine to create a serious competitor to NVIDIA\'s dominance in training hardware...' },
-                    ].map((item, i) => (
-                      <div
-                        key={item.tag}
-                        className={`py-2 ${i < 2 ? 'border-b border-[var(--color-border)]' : ''} text-xs flex items-start gap-2 flex-wrap ${
-                          item.active ? 'bg-[rgba(109,90,255,0.04)] -mx-3 px-3 py-2' : ''
+                      { name: 'Rust', active: true },
+                      { name: 'AI', active: true },
+                      { name: 'MCP', active: true },
+                      { name: 'Web', active: false },
+                      { name: 'Security', active: false },
+                    ].map((t) => (
+                      <span
+                        key={t.name}
+                        className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${
+                          t.active
+                            ? 'bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] text-[var(--color-accent)]'
+                            : 'bg-transparent border border-[var(--color-border)] text-[var(--color-text-dim)]'
                         }`}
                       >
-                        <span className="font-mono text-[0.6rem] font-semibold uppercase tracking-wide text-[var(--color-accent)] bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] px-1.5 py-0.5 rounded shrink-0">
-                          {item.tag}
-                        </span>
-                        <span className="text-[var(--color-text)]">{item.text}</span>
-                        {item.active && item.expanded && (
-                          <div className="w-full mt-1.5 pt-1.5 border-t border-[var(--color-border)] text-[0.75rem] text-[var(--color-text-muted)] leading-relaxed">
-                            {item.expanded}
-                          </div>
-                        )}
-                      </div>
+                        {t.active ? '✓ ' : ''}{t.name}
+                      </span>
                     ))}
                   </div>
                 </div>
-                <div className="self-end bg-[var(--color-accent)] text-white text-xs px-3 py-1.5 rounded-lg rounded-br-sm max-w-[80%]">
-                  Skip industry, more on the research
+                {/* Settings */}
+                <div className="space-y-2">
+                  <SettingRow label="Theme" value="Daltonian" />
+                  <SettingRow label="Summary" value="Standard" />
+                  <SettingRow label="Delivery" value="Weekdays · 9:00 AM" />
+                </div>
+                {/* Conversation snippet */}
+                <div className="border-t border-[var(--color-border)] pt-3">
+                  <div className="flex items-start gap-2 text-xs">
+                    <span className="text-[var(--color-accent)] shrink-0 mt-0.5">&#9656;</span>
+                    <span className="text-[var(--color-text-muted)] italic">"Use colorblind-safe theme with emoji headers"</span>
+                  </div>
+                  <div className="flex items-start gap-2 text-xs mt-2">
+                    <span className="text-[var(--color-accent-secondary)] shrink-0 mt-0.5">&#9671;</span>
+                    <span className="text-[var(--color-text-dim)]">Updated! Daltonian theme + emoji headers applied.</span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <p className="text-center text-sm text-[var(--color-text-muted)] mt-4 font-medium">Delivered to you. Interactive. On your terms.</p>
-          </div>
+            </MockClaudeWindow>
+          </Step>
         </div>
       </div>
     </section>
+  );
+}
+
+/* ─── Sub-components ─── */
+
+function Step({
+  index,
+  visible,
+  tag,
+  title,
+  description,
+  highlight,
+  link,
+  children,
+}: {
+  index: number;
+  visible: boolean;
+  tag: string;
+  title: string;
+  description: string;
+  highlight: string;
+  link?: { href: string; label: string };
+  children: React.ReactNode;
+}) {
+  const reverse = index % 2 === 1;
+  return (
+    <div
+      className={`grid grid-cols-1 md:grid-cols-2 gap-12 items-center transition-all duration-700 ease-out ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+      }`}
+      style={{ transitionDelay: `${index * 100}ms` }}
+    >
+      <div className={reverse ? 'md:order-2' : ''}>
+        <span className="inline-block font-mono text-xs font-semibold uppercase tracking-wider text-[var(--color-accent)] mb-3">
+          {tag}
+        </span>
+        <h3 className="text-2xl font-extrabold tracking-tight mb-3">{title}</h3>
+        <p className="text-[var(--color-text-muted)] leading-relaxed mb-3">{description}</p>
+        <p className="text-sm text-[var(--color-accent)] font-medium">{highlight}</p>
+        {link && (
+          <a
+            href={link.href}
+            className="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] mt-3 transition-colors"
+          >
+            {link.label} &rarr;
+          </a>
+        )}
+      </div>
+      <div className={reverse ? 'md:order-1' : ''}>{children}</div>
+    </div>
+  );
+}
+
+function MockClaudeWindow({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-[var(--color-bg-elevated)] border border-[var(--color-border)] rounded-2xl overflow-hidden shadow-[0_0_40px_var(--color-accent-glow)]">
+      {/* Title bar */}
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-[var(--color-border)]">
+        <div className="flex gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-full bg-[#ff5f57]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#febc2e]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
+        </div>
+        <span className="font-mono text-[0.65rem] text-[var(--color-text-dim)] ml-2">{title}</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ItemRow({
+  topic,
+  headline,
+  meta,
+  expanded,
+  summary,
+}: {
+  topic: string;
+  headline: string;
+  meta: string;
+  expanded?: boolean;
+  summary?: string;
+}) {
+  return (
+    <div className={`p-3 rounded-lg border transition-all ${
+      expanded
+        ? 'bg-[rgba(109,90,255,0.04)] border-[var(--color-tag-border)]'
+        : 'bg-[var(--color-bg-card)] border-[var(--color-border)]'
+    }`}>
+      <div className="flex items-start gap-2">
+        <span className="inline-block text-[0.6rem] font-semibold uppercase tracking-wider text-[var(--color-accent)] bg-[var(--color-tag-bg)] border border-[var(--color-tag-border)] px-1.5 py-0.5 rounded shrink-0 mt-0.5">
+          {topic}
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">{headline}</p>
+          <p className="text-[0.65rem] text-[var(--color-text-dim)] mt-0.5">{meta}</p>
+        </div>
+      </div>
+      {expanded && summary && (
+        <p className="text-xs text-[var(--color-text-muted)] mt-2 pt-2 border-t border-[var(--color-border)] leading-relaxed">
+          {summary}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function SettingRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between py-1.5 px-3 rounded-lg bg-[var(--color-bg-card)] border border-[var(--color-border)]">
+      <span className="text-xs text-[var(--color-text-dim)]">{label}</span>
+      <span className="text-xs font-medium text-[var(--color-text)]">{value}</span>
+    </div>
   );
 }

--- a/website/src/components/ThemePreview.tsx
+++ b/website/src/components/ThemePreview.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface ThemeColors {
+  bg: string;
+  cardBg: string;
+  text: string;
+  muted: string;
+  dim: string;
+  accent: string;
+  accentSecondary: string;
+  border: string;
+  tagBg: string;
+  tagBorder: string;
+}
+
+interface ThemeDef {
+  id: string;
+  name: string;
+  tagline: string;
+  colors: ThemeColors;
+  font?: string;
+  tight?: boolean;
+  headlinesOnly?: boolean;
+}
+
+const themes: ThemeDef[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    tagline: 'Dark theme with purple accents',
+    colors: {
+      bg: '#09090b', cardBg: '#18181b', text: '#fafafa', muted: '#a1a1aa', dim: '#71717a',
+      accent: '#6d5aff', accentSecondary: '#22d3ee', border: '#27272a',
+      tagBg: 'rgba(109,90,255,0.1)', tagBorder: 'rgba(109,90,255,0.25)',
+    },
+  },
+  {
+    id: 'daltonian',
+    name: 'Daltonian',
+    tagline: 'Colorblind-safe palette',
+    colors: {
+      bg: '#0a0a0f', cardBg: '#151520', text: '#e8e8f0', muted: '#9898a8', dim: '#686878',
+      accent: '#4cc9f0', accentSecondary: '#f77f00', border: '#252535',
+      tagBg: 'rgba(76,201,240,0.1)', tagBorder: 'rgba(76,201,240,0.25)',
+    },
+  },
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    tagline: 'Headlines only, zero noise',
+    colors: {
+      bg: '#0a0a0a', cardBg: '#111111', text: '#d4d4d4', muted: '#888888', dim: '#666666',
+      accent: '#999999', accentSecondary: '#999999', border: '#222222',
+      tagBg: 'rgba(153,153,153,0.1)', tagBorder: 'rgba(153,153,153,0.2)',
+    },
+    font: "'JetBrains Mono', monospace",
+    tight: true,
+    headlinesOnly: true,
+  },
+];
+
+const items = [
+  { topic: 'Rust', headline: 'Async closures ship in Rust 1.94', meta: 'blog.rust-lang.org · 4 min', summary: 'Async closures hit stable, eliminating a major pain point.' },
+  { topic: 'AI', headline: 'MCP Apps spec reaches v1.0', meta: 'modelcontextprotocol.io · 3 min', summary: 'The interactive UI extension for MCP is now finalized.' },
+];
+
+export default function ThemePreview() {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) setVisible(true); },
+      { threshold: 0.15 },
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <section className="py-28 relative z-[1]" ref={ref}>
+      <div className="max-w-[1200px] mx-auto px-8">
+        {/* Header */}
+        <div className="text-center mb-16">
+          <span className="inline-block font-mono text-xs font-medium text-[var(--color-accent)] uppercase tracking-widest mb-4">
+            Themes
+          </span>
+          <h2 className="text-[clamp(2rem,5vw,3.2rem)] font-extrabold tracking-tight leading-tight mb-4">
+            Your digest,{' '}
+            <span className="bg-gradient-to-r from-[var(--color-accent)] to-[var(--color-accent-secondary)] bg-clip-text text-transparent">
+              your style
+            </span>
+          </h2>
+          <p className="text-lg text-[var(--color-text-muted)] max-w-[520px] mx-auto">
+            Choose from 5 preset themes or describe your own with natural language.
+          </p>
+        </div>
+
+        {/* Theme cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {themes.map((theme, i) => (
+            <div
+              key={theme.id}
+              className={`transition-all duration-700 ease-out ${
+                visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'
+              }`}
+              style={{ transitionDelay: `${i * 120}ms` }}
+            >
+              <div
+                className="rounded-2xl border overflow-hidden h-full"
+                style={{
+                  backgroundColor: theme.colors.bg,
+                  borderColor: theme.colors.border,
+                  fontFamily: theme.font || "'Inter', sans-serif",
+                  color: theme.colors.text,
+                }}
+              >
+                {/* Card header */}
+                <div
+                  className="px-4 py-3 flex items-center justify-between border-b"
+                  style={{ borderColor: theme.colors.border }}
+                >
+                  <span className="font-semibold text-xs" style={{ color: theme.colors.accent }}>
+                    {theme.name}
+                  </span>
+                  <span className="text-[0.6rem]" style={{ color: theme.colors.dim }}>
+                    {theme.tagline}
+                  </span>
+                </div>
+
+                {/* Items */}
+                <div className={`px-4 ${theme.tight ? 'py-2' : 'py-3'} space-y-${theme.tight ? '1' : '2'}`}>
+                  {items.map((item, j) => (
+                    <div key={j} className={j < items.length - 1 ? 'pb-2 border-b' : ''} style={{ borderColor: theme.colors.border }}>
+                      <div className="flex items-start gap-1.5 mb-0.5">
+                        <span
+                          className="inline-block text-[0.55rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full shrink-0"
+                          style={{
+                            color: j === 0 ? theme.colors.accent : theme.colors.accentSecondary,
+                            backgroundColor: j === 0 ? theme.colors.tagBg : `${theme.colors.accentSecondary}15`,
+                            border: `1px solid ${j === 0 ? theme.colors.tagBorder : `${theme.colors.accentSecondary}40`}`,
+                          }}
+                        >
+                          {item.topic}
+                        </span>
+                      </div>
+                      <p className={`font-semibold ${theme.tight ? 'text-[0.7rem]' : 'text-xs'} leading-snug`}>
+                        {item.headline}
+                      </p>
+                      <p className="text-[0.6rem] mt-0.5" style={{ color: theme.colors.dim }}>
+                        {item.meta}
+                      </p>
+                      {!theme.headlinesOnly && (
+                        <p className="text-[0.65rem] mt-1 leading-relaxed" style={{ color: theme.colors.muted }}>
+                          {item.summary}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          className={`text-center mt-10 transition-all duration-700 ease-out ${
+            visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+          }`}
+          style={{ transitionDelay: '400ms' }}
+        >
+          <p className="text-sm text-[var(--color-text-muted)] mb-4">
+            5 presets available. Or just tell Claude what you want.
+          </p>
+          <a
+            href="/themes"
+            className="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)] hover:text-[var(--color-accent-hover)] transition-colors"
+          >
+            Explore all themes &rarr;
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,6 +7,7 @@ import HowItsDifferent from '../components/HowItsDifferent';
 import Features from '../components/Features';
 import Architecture from '../components/Architecture';
 import TechStack from '../components/TechStack';
+import ThemePreview from '../components/ThemePreview';
 import CTA from '../components/CTA';
 import Footer from '../components/Footer.astro';
 ---
@@ -19,6 +20,7 @@ import Footer from '../components/Footer.astro';
   <Features client:visible />
   <Architecture client:visible />
   <TechStack client:visible />
+  <ThemePreview client:visible />
   <CTA client:visible />
   <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- **#93** — Replaced the traditional-vs-ferrisletter comparison in "How It Works" with a 4-step walkthrough showcasing MCP App UI panels (Connect, Browse, Search, Personalize), each with a MockClaudeWindow rendering realistic UI mockups
- **#94** — Added a ThemePreview section to the landing page showing 3 digest themes (Default, Daltonian, Minimal) as side-by-side cards with scoped CSS, linking to /themes for the full gallery

## Files changed
- `website/src/components/HowItsDifferent.tsx` — Complete rewrite: 4-step layout with MockClaudeWindow, ItemRow, SettingRow sub-components
- `website/src/components/ThemePreview.tsx` — New component: 3 theme preview cards with IntersectionObserver animations
- `website/src/pages/index.astro` — Added ThemePreview between TechStack and CTA

## Test plan
- [x] `cd website && npm run build` succeeds — 10 pages, zero errors
- [x] All Rust tests pass (pre-push hook)
- [ ] Visual review of How It Works section (4 steps with alternating layout)
- [ ] Visual review of Theme Preview section (3 cards, responsive stacking)
- [ ] Links to /connect, /features, /themes work correctly

Closes #93, #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)