### PR TITLE
feat: favorites system — save, list, and remove favorite articles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ ferrisletter/
 3. `ferrisletter_get_item` — Fetch full content of a single item
 4. `ferrisletter_search` — Keyword search with filters
 5. `ferrisletter_recap` — Summarize items since a given date
+6. `ferrisletter_add_favorite` — Save an article to favorites
+7. `ferrisletter_remove_favorite` — Remove an article from favorites
+8. `ferrisletter_list_favorites` — List saved favorites with full item details
 
 ## MCP App UI
 
@@ -48,7 +51,18 @@ The UI follows the MCP Apps spec (`@modelcontextprotocol/ext-apps`):
 - `ui/src/App.tsx` — Root component, uses `useApp` hook, manages state
 - `ui/src/lib/mcp.ts` — SDK integration: `McpAppContext`, `inferToolResult()`, tool call helpers
 - `ui/src/views/CompactIssue.tsx` — Main digest view (topics, items, expand on click)
+- `ui/src/views/FavoritesPanel.tsx` — Favorites view (list saved articles, empty state)
 - `ui/src/lib/demo-data.ts` — Sample data for demo/standalone mode
+
+## Favorites System
+
+Server-level feature (not in the connector trait) — works with any connector.
+
+- **Storage**: `FavoriteStore` trait in `crates/server/src/favorites.rs`
+- **Default impl**: `InMemoryFavoriteStore` with JSON file persistence at `~/.config/ferrisletter/favorites.json`
+- **Type erasure**: `BoxedFavoriteStore` for external implementations (e.g. Lattice's database backend)
+- **User keying**: favorites are per-user (keyed by `user_id`, `"anonymous"` for stdio mode)
+- **Item resolution**: `list_favorites` stores only item IDs; resolves to full `Item` objects via the connector at query time
 
 ## Key Config Files
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -31,6 +31,7 @@ rmcp = { version = "1", features = ["server", "transport-io", "transport-streama
 anyhow = "1"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+dirs = "6"
 schemars = "1"
 thiserror = "2"
 toml = { version = "0.8", features = ["preserve_order"] }

--- a/crates/server/src/favorites.rs
+++ b/crates/server/src/favorites.rs
@@ -1,0 +1,378 @@
+//! Favorites storage — save, list, and remove favorite articles.
+//!
+//! The [`FavoriteStore`] trait defines the interface. Two implementations:
+//!
+//! - [`InMemoryFavoriteStore`] — for stdio/local mode, with optional JSON file
+//!   persistence at `~/.config/ferrisletter/favorites.json`.
+//! - External crates (e.g. Lattice) can provide a database-backed implementation.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// A single saved favorite.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FavoriteEntry {
+    pub item_id: String,
+    pub saved_at: DateTime<Utc>,
+}
+
+/// Async trait for favorite storage backends.
+pub trait FavoriteStore: Send + Sync {
+    fn add_favorite(
+        &self,
+        user_id: &str,
+        item_id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+
+    fn remove_favorite(
+        &self,
+        user_id: &str,
+        item_id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+
+    /// Returns item IDs, newest-saved first.
+    fn list_favorites(
+        &self,
+        user_id: &str,
+        limit: Option<usize>,
+    ) -> impl std::future::Future<Output = anyhow::Result<Vec<FavoriteEntry>>> + Send;
+
+    fn is_favorite(
+        &self,
+        user_id: &str,
+        item_id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<bool>> + Send;
+
+    fn count_favorites(
+        &self,
+        user_id: &str,
+    ) -> impl std::future::Future<Output = anyhow::Result<usize>> + Send;
+}
+
+// ── In-memory implementation ───────────────────────────────────────────────
+
+/// In-memory favorite store with optional JSON file persistence.
+///
+/// When `file_path` is `Some`, changes are flushed to disk after every
+/// mutation so that favorites survive server restarts.
+pub struct InMemoryFavoriteStore {
+    /// user_id → list of favorite entries (newest first).
+    data: Arc<RwLock<HashMap<String, Vec<FavoriteEntry>>>>,
+    file_path: Option<PathBuf>,
+}
+
+impl InMemoryFavoriteStore {
+    /// Create a new store. If `file_path` is provided and the file exists,
+    /// previously saved favorites are loaded from it.
+    pub fn new(file_path: Option<PathBuf>) -> Self {
+        let data = if let Some(ref path) = file_path {
+            Self::load_from_file(path).unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+        Self {
+            data: Arc::new(RwLock::new(data)),
+            file_path,
+        }
+    }
+
+    /// Default path: `~/.config/ferrisletter/favorites.json`.
+    pub fn default_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|d| d.join("ferrisletter").join("favorites.json"))
+    }
+
+    fn load_from_file(path: &std::path::Path) -> Option<HashMap<String, Vec<FavoriteEntry>>> {
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    async fn flush(&self) {
+        let Some(ref path) = self.file_path else {
+            return;
+        };
+        let snapshot = self.data.read().await.clone();
+        let path = path.clone();
+        // Fire-and-forget: write in a blocking task so we don't block the
+        // async runtime, and don't fail the caller if disk write fails.
+        tokio::task::spawn_blocking(move || {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            match serde_json::to_string_pretty(&snapshot) {
+                Ok(json) => {
+                    if let Err(e) = std::fs::write(&path, json) {
+                        tracing::warn!("failed to write favorites file: {e}");
+                    }
+                }
+                Err(e) => tracing::warn!("failed to serialize favorites: {e}"),
+            }
+        });
+    }
+}
+
+impl FavoriteStore for InMemoryFavoriteStore {
+    async fn add_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<()> {
+        let mut data = self.data.write().await;
+        let entries = data.entry(user_id.to_string()).or_default();
+        // Idempotent: don't add if already favorited.
+        if entries.iter().any(|e| e.item_id == item_id) {
+            return Ok(());
+        }
+        entries.insert(
+            0,
+            FavoriteEntry {
+                item_id: item_id.to_string(),
+                saved_at: Utc::now(),
+            },
+        );
+        drop(data);
+        self.flush().await;
+        Ok(())
+    }
+
+    async fn remove_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<()> {
+        let mut data = self.data.write().await;
+        if let Some(entries) = data.get_mut(user_id) {
+            entries.retain(|e| e.item_id != item_id);
+        }
+        drop(data);
+        self.flush().await;
+        Ok(())
+    }
+
+    async fn list_favorites(
+        &self,
+        user_id: &str,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<FavoriteEntry>> {
+        let data = self.data.read().await;
+        let entries = data.get(user_id).cloned().unwrap_or_default();
+        match limit {
+            Some(n) => Ok(entries.into_iter().take(n).collect()),
+            None => Ok(entries),
+        }
+    }
+
+    async fn is_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<bool> {
+        let data = self.data.read().await;
+        Ok(data
+            .get(user_id)
+            .is_some_and(|entries| entries.iter().any(|e| e.item_id == item_id)))
+    }
+
+    async fn count_favorites(&self, user_id: &str) -> anyhow::Result<usize> {
+        let data = self.data.read().await;
+        Ok(data.get(user_id).map_or(0, |e| e.len()))
+    }
+}
+
+// ── Type-erased wrapper ────────────────────────────────────────────────────
+
+/// Type-erased favorite store for use behind `Arc<dyn …>`.
+///
+/// Uses the same pattern as `BoxedConnector` — an internal `ErasedFavoriteStore`
+/// trait with boxed futures to erase the RPIT lifetime from `FavoriteStore`.
+///
+/// Every method takes `&self` with a unified `'a` lifetime that covers all
+/// borrowed parameters so the returned boxed future can reference them.
+trait ErasedFavoriteStore: Send + Sync {
+    fn add_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+    fn remove_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+    fn list_favorites<'a>(
+        &'a self,
+        user_id: &'a str,
+        limit: Option<usize>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<Vec<FavoriteEntry>>> + Send + 'a>,
+    >;
+
+    fn is_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<bool>> + Send + 'a>>;
+
+    fn count_favorites<'a>(
+        &'a self,
+        user_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<usize>> + Send + 'a>>;
+}
+
+impl<T: FavoriteStore> ErasedFavoriteStore for T {
+    fn add_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        Box::pin(FavoriteStore::add_favorite(self, user_id, item_id))
+    }
+
+    fn remove_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        Box::pin(FavoriteStore::remove_favorite(self, user_id, item_id))
+    }
+
+    fn list_favorites<'a>(
+        &'a self,
+        user_id: &'a str,
+        limit: Option<usize>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<Vec<FavoriteEntry>>> + Send + 'a>,
+    > {
+        Box::pin(FavoriteStore::list_favorites(self, user_id, limit))
+    }
+
+    fn is_favorite<'a>(
+        &'a self,
+        user_id: &'a str,
+        item_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<bool>> + Send + 'a>>
+    {
+        Box::pin(FavoriteStore::is_favorite(self, user_id, item_id))
+    }
+
+    fn count_favorites<'a>(
+        &'a self,
+        user_id: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<usize>> + Send + 'a>>
+    {
+        Box::pin(FavoriteStore::count_favorites(self, user_id))
+    }
+}
+
+/// Type-erased favorite store that can be shared across async tasks.
+pub struct BoxedFavoriteStore(Box<dyn ErasedFavoriteStore>);
+
+impl BoxedFavoriteStore {
+    pub fn new<T: FavoriteStore + 'static>(store: T) -> Self {
+        Self(Box::new(store))
+    }
+
+    pub async fn add_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<()> {
+        self.0.add_favorite(user_id, item_id).await
+    }
+
+    pub async fn remove_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<()> {
+        self.0.remove_favorite(user_id, item_id).await
+    }
+
+    pub async fn list_favorites(
+        &self,
+        user_id: &str,
+        limit: Option<usize>,
+    ) -> anyhow::Result<Vec<FavoriteEntry>> {
+        self.0.list_favorites(user_id, limit).await
+    }
+
+    pub async fn is_favorite(&self, user_id: &str, item_id: &str) -> anyhow::Result<bool> {
+        self.0.is_favorite(user_id, item_id).await
+    }
+
+    pub async fn count_favorites(&self, user_id: &str) -> anyhow::Result<usize> {
+        self.0.count_favorites(user_id).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Alias to disambiguate from the ErasedFavoriteStore blanket impl.
+    async fn add(s: &InMemoryFavoriteStore, u: &str, id: &str) {
+        FavoriteStore::add_favorite(s, u, id).await.unwrap();
+    }
+    async fn remove(s: &InMemoryFavoriteStore, u: &str, id: &str) {
+        FavoriteStore::remove_favorite(s, u, id).await.unwrap();
+    }
+    async fn list(s: &InMemoryFavoriteStore, u: &str, limit: Option<usize>) -> Vec<FavoriteEntry> {
+        FavoriteStore::list_favorites(s, u, limit).await.unwrap()
+    }
+    async fn is_fav(s: &InMemoryFavoriteStore, u: &str, id: &str) -> bool {
+        FavoriteStore::is_favorite(s, u, id).await.unwrap()
+    }
+    async fn count(s: &InMemoryFavoriteStore, u: &str) -> usize {
+        FavoriteStore::count_favorites(s, u).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn add_and_list_favorites() {
+        let store = InMemoryFavoriteStore::new(None);
+        add(&store, "anon", "item-1").await;
+        add(&store, "anon", "item-2").await;
+
+        let favs = list(&store, "anon", None).await;
+        assert_eq!(favs.len(), 2);
+        // Newest first.
+        assert_eq!(favs[0].item_id, "item-2");
+        assert_eq!(favs[1].item_id, "item-1");
+    }
+
+    #[tokio::test]
+    async fn add_favorite_is_idempotent() {
+        let store = InMemoryFavoriteStore::new(None);
+        add(&store, "anon", "item-1").await;
+        add(&store, "anon", "item-1").await;
+        assert_eq!(count(&store, "anon").await, 1);
+    }
+
+    #[tokio::test]
+    async fn remove_favorite() {
+        let store = InMemoryFavoriteStore::new(None);
+        add(&store, "anon", "item-1").await;
+        add(&store, "anon", "item-2").await;
+        remove(&store, "anon", "item-1").await;
+
+        let favs = list(&store, "anon", None).await;
+        assert_eq!(favs.len(), 1);
+        assert_eq!(favs[0].item_id, "item-2");
+    }
+
+    #[tokio::test]
+    async fn is_favorite() {
+        let store = InMemoryFavoriteStore::new(None);
+        add(&store, "anon", "item-1").await;
+
+        assert!(is_fav(&store, "anon", "item-1").await);
+        assert!(!is_fav(&store, "anon", "item-2").await);
+    }
+
+    #[tokio::test]
+    async fn list_favorites_with_limit() {
+        let store = InMemoryFavoriteStore::new(None);
+        for i in 0..5 {
+            add(&store, "anon", &format!("item-{i}")).await;
+        }
+        let favs = list(&store, "anon", Some(3)).await;
+        assert_eq!(favs.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn separate_users() {
+        let store = InMemoryFavoriteStore::new(None);
+        add(&store, "alice", "item-1").await;
+        add(&store, "bob", "item-2").await;
+
+        assert_eq!(count(&store, "alice").await, 1);
+        assert_eq!(count(&store, "bob").await, 1);
+        assert!(is_fav(&store, "alice", "item-1").await);
+        assert!(!is_fav(&store, "alice", "item-2").await);
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -10,15 +10,18 @@
 //! use std::sync::Arc;
 //! use tokio::sync::RwLock;
 //! use ferrisletter_connector::BoxedConnector;
-//! use ferrisletter_server::{FerrislletterServer, transport};
+//! use ferrisletter_server::{BoxedFavoriteStore, FerrislletterServer, InMemoryFavoriteStore, transport};
 //!
 //! # async fn run() -> anyhow::Result<()> {
 //! // Create your connector (any implementation of the Connector trait).
 //! # let my_connector: Arc<BoxedConnector> = todo!();
 //! let handle = Arc::new(RwLock::new(my_connector));
 //!
+//! // Create a favorites store.
+//! let favorites = Arc::new(BoxedFavoriteStore::new(InMemoryFavoriteStore::new(None)));
+//!
 //! // Build the MCP server.
-//! let server = FerrislletterServer::new(handle, /* ui_enabled */ true);
+//! let server = FerrislletterServer::new(handle, /* ui_enabled */ true, favorites);
 //!
 //! // Start over stdio transport.
 //! transport::serve_stdio(server).await?;
@@ -28,6 +31,7 @@
 
 pub mod api;
 pub mod config;
+pub mod favorites;
 pub mod health;
 pub mod server;
 #[cfg(feature = "telemetry")]
@@ -35,6 +39,7 @@ pub mod telemetry;
 pub mod transport;
 
 pub use config::{AdminConfig, Config, ConnectorConfig, TelemetryConfig, TransportMode, UiConfig};
+pub use favorites::{BoxedFavoriteStore, FavoriteStore, InMemoryFavoriteStore};
 pub use health::ServerState;
 pub use server::{FerrislletterServer, UI_RESOURCE_URI};
 pub use transport::{serve_sse, serve_stdio};

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -6,6 +6,7 @@ use ferrisletter_connector_rss::RssConnectorFactory;
 use ferrisletter_connector_static::StaticConnectorFactory;
 use ferrisletter_server::api::{ApiState, ConnectorHandle, FeedRecord, TopicRecord};
 use ferrisletter_server::config::{ConnectorConfig, TransportMode};
+use ferrisletter_server::favorites::{BoxedFavoriteStore, InMemoryFavoriteStore};
 use ferrisletter_server::server::FerrislletterServer;
 use ferrisletter_server::transport::{self, SseConfig};
 use ferrisletter_server::{config, server};
@@ -78,7 +79,14 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    let mcp_server = FerrislletterServer::new(connector_handle, cfg.ui.enabled);
+    // Build the favorites store with file persistence.
+    let favorites_path = InMemoryFavoriteStore::default_path();
+    tracing::info!(path = ?favorites_path, "favorites store initialised");
+    let favorites = Arc::new(BoxedFavoriteStore::new(InMemoryFavoriteStore::new(
+        favorites_path,
+    )));
+
+    let mcp_server = FerrislletterServer::new(connector_handle, cfg.ui.enabled, favorites);
 
     // Start MCP transport.
     match cfg.transport.mode {

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::favorites::BoxedFavoriteStore;
 use chrono::DateTime;
 use ferrisletter_connector::{
     BoxedConnector, Connector, Item, ItemDetail, Link, SearchFilters, Topic, UserPrefs,
@@ -42,15 +43,22 @@ pub struct FerrislletterServer {
     /// Whether the connected client supports the MCP-UI extension.
     /// Set during the MCP initialization handshake.
     client_supports_ui: Arc<AtomicBool>,
+    /// Favorites store (shared, type-erased).
+    favorites: Arc<BoxedFavoriteStore>,
     tool_router: ToolRouter<Self>,
 }
 
 impl FerrislletterServer {
-    pub fn new(connector: ConnectorHandle, ui_enabled: bool) -> Self {
+    pub fn new(
+        connector: ConnectorHandle,
+        ui_enabled: bool,
+        favorites: Arc<BoxedFavoriteStore>,
+    ) -> Self {
         Self {
             connector,
             ui_enabled,
             client_supports_ui: Arc::new(AtomicBool::new(false)),
+            favorites,
             tool_router: Self::tool_router(),
         }
     }
@@ -249,6 +257,24 @@ pub struct RecapParams {
     pub topics: Option<Vec<String>>,
     /// Maximum number of items to return.
     pub max_items: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AddFavoriteParams {
+    /// Item ID to save as a favorite.
+    pub item_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RemoveFavoriteParams {
+    /// Item ID to remove from favorites.
+    pub item_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListFavoritesParams {
+    /// Maximum number of favorites to return.
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -459,6 +485,145 @@ impl FerrislletterServer {
         }
         Ok(tool_ok_text(json))
     }
+
+    /// Save an article to favorites.
+    #[tool(description = "Save an article to favorites. \
+        Pass the item_id as returned by ferrisletter_get_latest or ferrisletter_search.")]
+    #[tracing::instrument(skip(self), name = "tool:add_favorite")]
+    async fn ferrisletter_add_favorite(
+        &self,
+        Parameters(params): Parameters<AddFavoriteParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let user_id = "anonymous";
+        self.favorites
+            .add_favorite(user_id, &params.item_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let count = self
+            .favorites
+            .count_favorites(user_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let resp = serde_json::json!({
+            "status": "saved",
+            "item_id": params.item_id,
+            "total_favorites": count,
+        });
+        let json = serde_json::to_string_pretty(&resp)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        if self.should_use_ui() {
+            return Ok(tool_ok_ui(json, count, "favorites"));
+        }
+        Ok(tool_ok_text(format!(
+            "Saved to favorites. You now have {count} favorite(s)."
+        )))
+    }
+
+    /// Remove an article from favorites.
+    #[tool(description = "Remove an article from favorites. \
+        Pass the item_id to unfavorite.")]
+    #[tracing::instrument(skip(self), name = "tool:remove_favorite")]
+    async fn ferrisletter_remove_favorite(
+        &self,
+        Parameters(params): Parameters<RemoveFavoriteParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let user_id = "anonymous";
+        self.favorites
+            .remove_favorite(user_id, &params.item_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let count = self
+            .favorites
+            .count_favorites(user_id)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        let resp = serde_json::json!({
+            "status": "removed",
+            "item_id": params.item_id,
+            "total_favorites": count,
+        });
+        let json = serde_json::to_string_pretty(&resp)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        if self.should_use_ui() {
+            return Ok(tool_ok_ui(json, count, "favorites"));
+        }
+        Ok(tool_ok_text(format!(
+            "Removed from favorites. You now have {count} favorite(s)."
+        )))
+    }
+
+    /// List saved favorites.
+    #[tool(
+        description = "List saved favorites. Returns full item details for each favorited article. \
+        Use limit to cap the number of results."
+    )]
+    #[tracing::instrument(skip(self), name = "tool:list_favorites")]
+    async fn ferrisletter_list_favorites(
+        &self,
+        Parameters(params): Parameters<ListFavoritesParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let user_id = "anonymous";
+        let entries = self
+            .favorites
+            .list_favorites(user_id, params.limit)
+            .await
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+
+        // Resolve item IDs to full Items via the connector.
+        let conn = self.conn().await;
+        let mut items: Vec<Item> = Vec::new();
+        for entry in &entries {
+            match conn.get_item_detail(&entry.item_id).await {
+                Ok(detail) => items.push(detail.item),
+                Err(_) => {
+                    // Item may have been removed from the feed — include a stub.
+                    items.push(Item {
+                        id: entry.item_id.clone(),
+                        topic_id: String::new(),
+                        headline: format!("[unavailable] {}", entry.item_id),
+                        summary: String::new(),
+                        tags: Vec::new(),
+                        source: String::new(),
+                        published: entry.saved_at,
+                    });
+                }
+            }
+        }
+
+        let count = items.len();
+        if self.should_use_ui() {
+            let json = serde_json::to_string_pretty(&items)
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            return Ok(tool_ok_ui(json, count, "favorites"));
+        }
+
+        if items.is_empty() {
+            return Ok(tool_ok_text(
+                "No favorites yet. Save articles you want to revisit with ferrisletter_add_favorite."
+                    .to_string(),
+            ));
+        }
+
+        let mut text = format!("You have {} saved favorite(s):\n", count);
+        for (i, item) in items.iter().enumerate() {
+            let date = item.published.format("%Y-%m-%d");
+            text.push_str(&format!("\n{}. **{}**", i + 1, item.headline));
+            if !item.source.is_empty() {
+                text.push_str(&format!("\n   {} | {}", item.source, date));
+            }
+            if let Some(entry) = entries.get(i) {
+                let saved = entry.saved_at.format("%Y-%m-%d");
+                text.push_str(&format!("\n   Saved on: {saved}"));
+            }
+        }
+        Ok(tool_ok_text(text))
+    }
 }
 
 impl ServerHandler for FerrislletterServer {
@@ -488,7 +653,9 @@ impl ServerHandler for FerrislletterServer {
                 then `ferrisletter_get_latest` to browse headlines. \
                 Expand anything interesting with `ferrisletter_get_item`, \
                 search across past content with `ferrisletter_search`, \
-                or catch up on what you missed with `ferrisletter_recap`.",
+                or catch up on what you missed with `ferrisletter_recap`. \
+                Save articles with `ferrisletter_add_favorite` and retrieve them later \
+                with `ferrisletter_list_favorites`.",
             )
     }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { CompactIssue } from "@/views/CompactIssue";
 import { SearchPanel } from "@/views/SearchPanel";
 import { RecapPanel } from "@/views/RecapPanel";
+import { FavoritesPanel } from "@/views/FavoritesPanel";
 import { ViewToggle } from "@/components/ViewToggle";
 import {
   McpAppContext,
@@ -141,6 +142,10 @@ export default function App() {
 
         {activeView === "recap" && (
           <RecapPanel topics={topics} isDemo={isDemo} />
+        )}
+
+        {activeView === "favorites" && (
+          <FavoritesPanel topics={topics} isDemo={isDemo} />
         )}
       </div>
     </McpAppContext.Provider>

--- a/ui/src/components/ViewToggle.tsx
+++ b/ui/src/components/ViewToggle.tsx
@@ -1,4 +1,4 @@
-import { Newspaper, Search, Clock } from "lucide-react";
+import { Newspaper, Search, Clock, Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ViewMode } from "@/types";
 
@@ -11,6 +11,7 @@ const TABS: { mode: ViewMode; label: string; icon: typeof Search }[] = [
   { mode: "digest", label: "Digest", icon: Newspaper },
   { mode: "search", label: "Search", icon: Search },
   { mode: "recap", label: "Recap", icon: Clock },
+  { mode: "favorites", label: "Favorites", icon: Heart },
 ];
 
 export function ViewToggle({ activeView, onChange }: ViewToggleProps) {

--- a/ui/src/lib/mcp.ts
+++ b/ui/src/lib/mcp.ts
@@ -129,3 +129,38 @@ export async function recapItems(
   });
   return extractJson(result) as Item[];
 }
+
+// ── Favorites ──────────────────────────────────────────────────────────────
+
+export async function addFavorite(
+  app: App,
+  itemId: string,
+): Promise<{ status: string; total_favorites: number }> {
+  const result = await app.callServerTool({
+    name: "ferrisletter_add_favorite",
+    arguments: { item_id: itemId },
+  });
+  return extractJson(result) as { status: string; total_favorites: number };
+}
+
+export async function removeFavorite(
+  app: App,
+  itemId: string,
+): Promise<{ status: string; total_favorites: number }> {
+  const result = await app.callServerTool({
+    name: "ferrisletter_remove_favorite",
+    arguments: { item_id: itemId },
+  });
+  return extractJson(result) as { status: string; total_favorites: number };
+}
+
+export async function listFavorites(
+  app: App,
+  limit?: number,
+): Promise<Item[]> {
+  const result = await app.callServerTool({
+    name: "ferrisletter_list_favorites",
+    arguments: { limit },
+  });
+  return extractJson(result) as Item[];
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -21,7 +21,7 @@ export interface ItemDetail extends Item {
   links: { url: string; label: string }[];
 }
 
-export type ViewMode = "digest" | "search" | "recap";
+export type ViewMode = "digest" | "search" | "recap" | "favorites";
 export type SortField = "date" | "read_time";
 export type SortDirection = "asc" | "desc";
 export interface SortState {

--- a/ui/src/views/FavoritesPanel.tsx
+++ b/ui/src/views/FavoritesPanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { Heart, Loader2 } from "lucide-react";
+import { ResultsList } from "@/components/ResultsList";
+import { useMcpApp, listFavorites } from "@/lib/mcp";
+import { DEMO_ITEMS } from "@/lib/demo-data";
+import type { Item, Topic, SortState } from "@/types";
+
+/** IDs of demo items that are pre-favorited in demo mode. */
+const DEMO_FAVORITE_IDS = ["demo-1", "demo-3", "demo-5"];
+
+interface FavoritesPanelProps {
+  topics: Topic[];
+  isDemo: boolean;
+}
+
+export function FavoritesPanel({ topics: _topics, isDemo }: FavoritesPanelProps) {
+  const app = useMcpApp();
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const [sort, setSort] = useState<SortState>({
+    field: "date",
+    direction: "desc",
+  });
+
+  const fetchFavorites = async () => {
+    setIsLoading(true);
+    try {
+      if (isDemo || !app) {
+        setItems(DEMO_ITEMS.filter((i) => DEMO_FAVORITE_IDS.includes(i.id)));
+      } else {
+        const favs = await listFavorites(app);
+        setItems(favs);
+      }
+    } catch {
+      setItems([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void fetchFavorites();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [app, isDemo]);
+
+  const handleTagToggle = (tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  };
+
+  return (
+    <div className="flex flex-col bg-[var(--color-bg-card)] rounded-lg border border-[var(--color-border)] overflow-hidden">
+      {/* header */}
+      <header className="px-4 py-3 border-b border-[var(--color-border)] shrink-0">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--color-text)] tracking-tight">
+            Saved favorites
+          </h2>
+          {!isLoading && items.length > 0 && (
+            <span className="text-[10px] font-medium text-[var(--color-text-dim)]">
+              {items.length} {items.length === 1 ? "article" : "articles"}
+            </span>
+          )}
+        </div>
+      </header>
+
+      {/* content */}
+      {isLoading ? (
+        <div className="flex items-center justify-center h-32 gap-2 text-sm text-[var(--color-text-dim)]">
+          <Loader2 size={14} className="animate-spin" aria-hidden />
+          Loading&hellip;
+        </div>
+      ) : items.length > 0 ? (
+        <ResultsList
+          items={items}
+          isDemo={isDemo}
+          activeTags={activeTags}
+          sort={sort}
+          onTagToggle={handleTagToggle}
+          onSortChange={setSort}
+          onTagsClear={() => setActiveTags([])}
+          emptyMessage="No favorites match your filters."
+        />
+      ) : (
+        <div className="flex flex-col items-center justify-center h-32 gap-2 text-[var(--color-text-dim)]">
+          <Heart size={20} aria-hidden />
+          <p className="text-sm">No favorites yet. Save articles you want to revisit.</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `FavoriteStore` trait + `InMemoryFavoriteStore` with JSON file persistence at `~/.config/ferrisletter/favorites.json`
- 3 new MCP tools: `ferrisletter_add_favorite`, `ferrisletter_remove_favorite`, `ferrisletter_list_favorites`
- Favorites tab (Heart icon) in the MCP App UI panel with `FavoritesPanel` view
- Updated CLAUDE.md with new tools and favorites architecture

## Test plan
- [x] `cargo test` — 18 server tests pass (6 favorites-specific)
- [x] `cargo clippy` / `cargo fmt` — clean
- [x] UI type-check (`npx tsc --noEmit`) — clean
- [x] Tested in Claude Desktop: add, list, remove favorites all work
- [x] Persistence: favorites survive server restart via JSON file
- [x] MCP App UI: Favorites tab renders with items / empty state

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)